### PR TITLE
Add admin UI with image gallery, upload, and collection-aware management (#108)

### DIFF
--- a/src/lib/admin/image-filter.test.ts
+++ b/src/lib/admin/image-filter.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import type { Image } from '$lib/data';
+import {
+    filterImages,
+    extractPrefixes,
+    buildImageUsageMap,
+    type Collections,
+} from './image-filter';
+
+const mockImages: Image[] = [
+    { id: 'illustration/1', format: 'jpeg', width: 800, height: 600, title: 'Illustration 1' },
+    { id: 'illustration/2', format: 'png', width: 1200, height: 800, title: 'Illustration 2' },
+    { id: 'top/1', format: 'jpeg', width: 1920, height: 1080, title: 'Top 1' },
+    { id: 'top/wide-1', format: 'jpeg', width: 1920, height: 960, title: 'Top Wide 1' },
+    { id: 'profile', format: 'jpeg', width: 3807, height: 2538, title: 'Profile' },
+    {
+        id: 'books/lost-in-the-rain/cover',
+        format: 'jpeg',
+        width: 800,
+        height: 1200,
+        title: 'Book Cover',
+    },
+];
+
+describe('filterImages', () => {
+    it('returns all images when query is empty', () => {
+        expect(filterImages(mockImages, '')).toEqual(mockImages);
+    });
+
+    it('filters by ID substring', () => {
+        const result = filterImages(mockImages, 'illustration');
+        expect(result).toHaveLength(2);
+        expect(result[0]!.id).toBe('illustration/1');
+        expect(result[1]!.id).toBe('illustration/2');
+    });
+
+    it('filters case-insensitively', () => {
+        const result = filterImages(mockImages, 'ILLUSTRATION');
+        expect(result).toHaveLength(2);
+    });
+
+    it('filters by prefix with slash', () => {
+        const result = filterImages(mockImages, 'top/');
+        expect(result).toHaveLength(2);
+    });
+
+    it('returns empty array when nothing matches', () => {
+        expect(filterImages(mockImages, 'nonexistent')).toEqual([]);
+    });
+});
+
+describe('extractPrefixes', () => {
+    it('extracts unique sorted prefixes', () => {
+        const prefixes = extractPrefixes(mockImages);
+        expect(prefixes).toEqual(['(root)', 'books', 'illustration', 'top']);
+    });
+
+    it('returns (root) for images without a slash', () => {
+        const images: Image[] = [
+            { id: 'profile', format: 'jpeg', width: 100, height: 100, title: 'Profile' },
+        ];
+        expect(extractPrefixes(images)).toEqual(['(root)']);
+    });
+
+    it('returns empty array for empty input', () => {
+        expect(extractPrefixes([])).toEqual([]);
+    });
+});
+
+describe('buildImageUsageMap', () => {
+    const collections: Collections = {
+        topImages: ['top/1'],
+        topImagesWide: ['top/wide-1'],
+        illustrations: ['illustration/1', 'illustration/2'],
+        works: [
+            {
+                id: 'lost-in-the-rain',
+                image: 'books/lost-in-the-rain/cover',
+                title: 'LOST IN THE RAIN',
+                images: ['books/lost-in-the-rain/cover', 'books/lost-in-the-rain/page1'],
+            },
+        ],
+    };
+
+    it('maps images to their collection usages', () => {
+        const map = buildImageUsageMap(collections);
+
+        expect(map.get('top/1')).toEqual([{ label: 'topImages', href: '/admin/collections' }]);
+
+        expect(map.get('top/wide-1')).toEqual([
+            { label: 'topImagesWide', href: '/admin/collections' },
+        ]);
+
+        expect(map.get('illustration/1')).toEqual([
+            { label: 'illustrations', href: '/admin/collections' },
+        ]);
+    });
+
+    it('maps images used in works with correct links', () => {
+        const map = buildImageUsageMap(collections);
+        const coverUsages = map.get('books/lost-in-the-rain/cover');
+
+        expect(coverUsages).toBeDefined();
+        expect(coverUsages).toContainEqual({ label: 'lost-in-the-rain', href: '/admin/works' });
+    });
+
+    it('returns undefined for unused images', () => {
+        const map = buildImageUsageMap(collections);
+        expect(map.get('profile')).toBeUndefined();
+    });
+
+    it('accumulates multiple usages for the same image', () => {
+        const map = buildImageUsageMap(collections);
+        const coverUsages = map.get('books/lost-in-the-rain/cover');
+
+        // Used as work.image AND in work.images
+        expect(coverUsages!.length).toBeGreaterThanOrEqual(2);
+    });
+});

--- a/src/lib/admin/image-filter.ts
+++ b/src/lib/admin/image-filter.ts
@@ -1,0 +1,64 @@
+import type { Image, Work } from '$lib/data';
+
+export interface Collections {
+    topImages: string[];
+    topImagesWide: string[];
+    works: Work[];
+    illustrations: string[];
+}
+
+export interface ImageUsage {
+    label: string;
+    href: string;
+}
+
+export function filterImages(images: Image[], query: string): Image[] {
+    if (!query) return images;
+    const lower = query.toLowerCase();
+    return images.filter((img) => img.id.toLowerCase().includes(lower));
+}
+
+export function extractPrefixes(images: Image[]): string[] {
+    const prefixes = new Set<string>();
+    for (const img of images) {
+        const slash = img.id.indexOf('/');
+        prefixes.add(slash >= 0 ? img.id.substring(0, slash) : '(root)');
+    }
+    return [...prefixes].sort();
+}
+
+export function buildImageUsageMap(collections: Collections): Map<string, ImageUsage[]> {
+    const map = new Map<string, ImageUsage[]>();
+
+    function add(imageId: string, usage: ImageUsage) {
+        const existing = map.get(imageId);
+        if (existing) {
+            existing.push(usage);
+        } else {
+            map.set(imageId, [usage]);
+        }
+    }
+
+    for (const id of collections.topImages) {
+        add(id, { label: 'topImages', href: '/admin/collections' });
+    }
+
+    for (const id of collections.topImagesWide) {
+        add(id, { label: 'topImagesWide', href: '/admin/collections' });
+    }
+
+    for (const id of collections.illustrations) {
+        add(id, { label: 'illustrations', href: '/admin/collections' });
+    }
+
+    for (const work of collections.works) {
+        if (work.image) {
+            add(work.image, { label: work.id, href: '/admin/works' });
+        }
+        for (const id of work.images) {
+            add(id, { label: work.id, href: '/admin/works' });
+        }
+    }
+
+    return map;
+}

--- a/src/lib/admin/image-thumbnail.svelte
+++ b/src/lib/admin/image-thumbnail.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+    import { imagePath } from '$lib/data';
+    import type { Image } from '$lib/data';
+    import type { ImageUsage } from './image-filter';
+
+    let {
+        image,
+        usages = [],
+        ondelete,
+    }: {
+        image: Image;
+        usages?: ImageUsage[];
+        ondelete?: (id: string) => void;
+    } = $props();
+
+    let imgError = $state(false);
+
+    let isUsed = $derived(usages.length > 0);
+
+    function handleDelete() {
+        if (isUsed || !ondelete) return;
+        ondelete(image.id);
+    }
+</script>
+
+<div class="relative group rounded-lg overflow-hidden shadow-sm border border-gray-200 bg-white">
+    {#if imgError}
+        <div class="w-full aspect-square bg-gray-100 flex items-center justify-center">
+            <span class="text-gray-400 text-xs">Failed to load</span>
+        </div>
+    {:else}
+        <img
+            src={imagePath(image.id, 'square')}
+            alt={image.id}
+            class="w-full aspect-square object-cover"
+            loading="lazy"
+            onerror={() => { imgError = true; }}
+        />
+    {/if}
+
+    <div class="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-50 transition-all pointer-events-none">
+        <div class="absolute bottom-0 left-0 right-0 p-2 text-white text-xs opacity-0 group-hover:opacity-100 transition-opacity">
+            <p class="truncate font-mono">{image.id}</p>
+            <p>{image.width}&times;{image.height} &middot; {image.format}</p>
+        </div>
+    </div>
+
+    {#if ondelete}
+        <button
+            type="button"
+            class="absolute top-1 right-1 opacity-0 group-hover:opacity-100 transition-opacity
+                   w-6 h-6 rounded text-xs flex items-center justify-center
+                   {isUsed
+                       ? 'bg-gray-300 text-gray-500 cursor-not-allowed'
+                       : 'bg-red-500 text-white hover:bg-red-600 cursor-pointer'}"
+            disabled={isUsed}
+            title={isUsed ? 'Cannot delete: image is used in collections' : 'Delete image'}
+            onclick={handleDelete}
+        >
+            &times;
+        </button>
+    {/if}
+
+    {#if usages.length > 0}
+        <div class="px-2 py-1 flex flex-wrap gap-1">
+            {#each usages as usage}
+                <a
+                    href={usage.href}
+                    class="inline-block text-xs px-1.5 py-0.5 rounded bg-blue-100 text-blue-700 hover:bg-blue-200 truncate max-w-full"
+                    title={usage.label}
+                >
+                    {usage.label}
+                </a>
+            {/each}
+        </div>
+    {/if}
+</div>

--- a/src/lib/admin/image-thumbnail.test.ts
+++ b/src/lib/admin/image-thumbnail.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import ImageThumbnail from './image-thumbnail.svelte';
+import type { Image } from '$lib/data';
+import type { ImageUsage } from './image-filter';
+
+vi.mock('$lib/data', () => ({
+    imagePath: (id: string, variant: string) => `https://imagedelivery.net/HASH/${id}/${variant}`,
+}));
+
+const mockImage: Image = {
+    id: 'illustration/1',
+    format: 'jpeg',
+    width: 800,
+    height: 600,
+    title: 'Test Image',
+};
+
+describe('ImageThumbnail', () => {
+    it('renders image with correct src from imagePath', () => {
+        render(ImageThumbnail, { props: { image: mockImage } });
+
+        const img = screen.getByRole('img');
+        expect(img).toHaveAttribute('src', 'https://imagedelivery.net/HASH/illustration/1/square');
+    });
+
+    it('displays image ID and dimensions', () => {
+        render(ImageThumbnail, { props: { image: mockImage } });
+
+        expect(screen.getByText('illustration/1')).toBeTruthy();
+        expect(screen.getByText(/800.*600.*jpeg/)).toBeTruthy();
+    });
+
+    it('calls ondelete when delete button is clicked on unused image', async () => {
+        const handleDelete = vi.fn();
+        render(ImageThumbnail, {
+            props: { image: mockImage, usages: [], ondelete: handleDelete },
+        });
+
+        const deleteBtn = screen.getByTitle('Delete image');
+        await fireEvent.click(deleteBtn);
+
+        expect(handleDelete).toHaveBeenCalledWith('illustration/1');
+    });
+
+    it('disables delete button when image is used in collections', () => {
+        const usages: ImageUsage[] = [{ label: 'topImages', href: '/admin/collections' }];
+        const handleDelete = vi.fn();
+        render(ImageThumbnail, {
+            props: { image: mockImage, usages, ondelete: handleDelete },
+        });
+
+        const deleteBtn = screen.getByTitle('Cannot delete: image is used in collections');
+        expect(deleteBtn).toBeDisabled();
+    });
+
+    it('renders usage labels as links', () => {
+        const usages: ImageUsage[] = [
+            { label: 'topImages', href: '/admin/collections' },
+            { label: 'zine-2023', href: '/admin/works' },
+        ];
+        render(ImageThumbnail, { props: { image: mockImage, usages } });
+
+        const links = screen.getAllByRole('link');
+        const topImagesLink = links.find((l) => l.textContent === 'topImages');
+        const workLink = links.find((l) => l.textContent === 'zine-2023');
+
+        expect(topImagesLink).toHaveAttribute('href', '/admin/collections');
+        expect(workLink).toHaveAttribute('href', '/admin/works');
+    });
+});

--- a/src/lib/admin/image-upload.svelte
+++ b/src/lib/admin/image-upload.svelte
@@ -1,0 +1,223 @@
+<script lang="ts">
+    import type { Image } from '$lib/data';
+
+    let {
+        existingIds = [],
+        onsuccess,
+    }: {
+        existingIds?: string[];
+        onsuccess?: (image: Image) => void;
+    } = $props();
+
+    const MAX_SIZE = 10 * 1024 * 1024;
+    const ACCEPTED_TYPES = ['image/jpeg', 'image/png'];
+
+    let dragActive = $state(false);
+    let file = $state<File | null>(null);
+    let customId = $state('');
+    let uploading = $state(false);
+    let progress = $state<'idle' | 'uploading' | 'success' | 'error'>('idle');
+    let errorMessage = $state('');
+    let previewUrl = $state<string | null>(null);
+
+    let validationError = $derived.by(() => {
+        if (!file) return '';
+        if (!ACCEPTED_TYPES.includes(file.type)) return 'Only JPEG and PNG files are accepted.';
+        if (file.size > MAX_SIZE) return `File exceeds 10MB limit (${(file.size / 1024 / 1024).toFixed(1)}MB).`;
+        return '';
+    });
+
+    let duplicateWarning = $derived(
+        customId && existingIds.includes(customId)
+            ? 'An image with this ID already exists and will be overwritten.'
+            : '',
+    );
+
+    $effect(() => {
+        if (file && !validationError) {
+            const url = URL.createObjectURL(file);
+            previewUrl = url;
+            return () => URL.revokeObjectURL(url);
+        } else {
+            previewUrl = null;
+            return undefined;
+        }
+    });
+
+    $effect(() => {
+        if (file && !customId) {
+            const name = file.name.replace(/\.[^.]+$/, '');
+            customId = name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
+        }
+    });
+
+    function selectFile(f: File) {
+        file = f;
+        customId = '';
+        progress = 'idle';
+        errorMessage = '';
+    }
+
+    function handleDragOver(e: DragEvent) {
+        e.preventDefault();
+        dragActive = true;
+    }
+
+    function handleDragLeave(e: DragEvent) {
+        e.preventDefault();
+        dragActive = false;
+    }
+
+    function handleDrop(e: DragEvent) {
+        e.preventDefault();
+        dragActive = false;
+        const f = e.dataTransfer?.files[0];
+        if (f) selectFile(f);
+    }
+
+    function handleFileSelect(e: Event) {
+        const input = e.target as HTMLInputElement;
+        const f = input.files?.[0];
+        if (f) selectFile(f);
+    }
+
+    function reset() {
+        file = null;
+        customId = '';
+        progress = 'idle';
+        errorMessage = '';
+        previewUrl = null;
+    }
+
+    async function handleUpload() {
+        if (!file || !customId || validationError) return;
+
+        uploading = true;
+        progress = 'uploading';
+        errorMessage = '';
+
+        const formData = new FormData();
+        formData.append('file', file);
+        formData.append('id', customId);
+
+        try {
+            const response = await fetch('/api/admin/images', {
+                method: 'POST',
+                body: formData,
+            });
+
+            if (!response.ok) {
+                const data = await response.json().catch(() => null);
+                throw new Error(
+                    (data && typeof data === 'object' && 'message' in data ? String(data.message) : null)
+                    ?? `Upload failed (${response.status})`,
+                );
+            }
+
+            const data = await response.json();
+            progress = 'success';
+            onsuccess?.(data.image);
+
+            setTimeout(reset, 2000);
+        } catch (e) {
+            progress = 'error';
+            errorMessage = e instanceof Error ? e.message : 'Upload failed';
+        } finally {
+            uploading = false;
+        }
+    }
+</script>
+
+<div
+    class="border-2 border-dashed rounded-lg p-6 transition-colors
+           {dragActive ? 'border-blue-400 bg-blue-50' : 'border-gray-300 bg-white'}"
+    role="region"
+    aria-label="Image upload"
+    ondragover={handleDragOver}
+    ondragenter={handleDragOver}
+    ondragleave={handleDragLeave}
+    ondrop={handleDrop}
+>
+    {#if !file}
+        <div class="text-center">
+            <p class="text-gray-500 mb-2">Drag & drop an image here, or</p>
+            <label class="cursor-pointer text-blue-600 hover:text-blue-700 underline">
+                browse files
+                <input
+                    type="file"
+                    accept="image/jpeg,image/png"
+                    class="hidden"
+                    onchange={handleFileSelect}
+                />
+            </label>
+            <p class="text-xs text-gray-400 mt-2">JPEG or PNG, max 10MB</p>
+        </div>
+    {:else}
+        <div class="flex gap-4 items-start">
+            {#if previewUrl}
+                <img
+                    src={previewUrl}
+                    alt="Preview"
+                    class="w-32 h-32 object-cover rounded border border-gray-200"
+                />
+            {/if}
+            <div class="flex-1">
+                {#if validationError}
+                    <p class="text-red-600 text-sm mb-2">{validationError}</p>
+                    <button
+                        type="button"
+                        class="text-sm text-gray-500 underline"
+                        onclick={reset}
+                    >
+                        Choose a different file
+                    </button>
+                {:else}
+                    <label class="block text-sm font-medium text-gray-700 mb-1">
+                        Image ID
+                        <input
+                            type="text"
+                            bind:value={customId}
+                            class="mt-1 block w-full border border-gray-300 rounded px-3 py-1.5 text-sm font-mono focus:outline-none focus:ring-1 focus:ring-blue-500"
+                            placeholder="e.g. illustration/my-image"
+                        />
+                    </label>
+                    {#if duplicateWarning}
+                        <p class="text-amber-600 text-xs mt-1">{duplicateWarning}</p>
+                    {/if}
+                    <p class="text-xs text-gray-500 mt-1">
+                        {file.name} ({(file.size / 1024).toFixed(0)} KB)
+                    </p>
+
+                    <div class="flex gap-2 mt-3">
+                        <button
+                            type="button"
+                            class="px-4 py-1.5 bg-blue-600 text-white rounded text-sm hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                            disabled={uploading || !customId}
+                            onclick={handleUpload}
+                        >
+                            {#if progress === 'uploading'}
+                                Uploading...
+                            {:else}
+                                Upload
+                            {/if}
+                        </button>
+                        <button
+                            type="button"
+                            class="px-4 py-1.5 bg-white border border-gray-300 text-gray-600 rounded text-sm hover:bg-gray-50"
+                            disabled={uploading}
+                            onclick={reset}
+                        >
+                            Cancel
+                        </button>
+                    </div>
+                {/if}
+            </div>
+        </div>
+
+        {#if progress === 'success'}
+            <p class="mt-3 text-green-600 text-sm">Upload successful!</p>
+        {:else if progress === 'error'}
+            <p class="mt-3 text-red-600 text-sm">{errorMessage}</p>
+        {/if}
+    {/if}
+</div>

--- a/src/lib/admin/image-upload.test.ts
+++ b/src/lib/admin/image-upload.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import ImageUpload from './image-upload.svelte';
+
+vi.mock('$lib/data', () => ({
+    imagePath: (id: string, variant: string) => `https://imagedelivery.net/HASH/${id}/${variant}`,
+}));
+
+function createMockFile(name: string, size: number, type: string): File {
+    const buffer = new ArrayBuffer(size);
+    return new File([buffer], name, { type });
+}
+
+describe('ImageUpload', () => {
+    it('renders the drop zone with upload instructions', () => {
+        render(ImageUpload);
+
+        expect(screen.getByText(/drag & drop/i)).toBeTruthy();
+        expect(screen.getByText('browse files')).toBeTruthy();
+    });
+
+    it('shows validation error for non-image file', async () => {
+        render(ImageUpload);
+
+        const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+        const textFile = createMockFile('document.txt', 1024, 'text/plain');
+
+        await fireEvent.change(input, { target: { files: [textFile] } });
+
+        expect(screen.getByText('Only JPEG and PNG files are accepted.')).toBeTruthy();
+    });
+
+    it('shows validation error for oversized file', async () => {
+        render(ImageUpload);
+
+        const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+        const largeFile = createMockFile('large.jpg', 11 * 1024 * 1024, 'image/jpeg');
+
+        await fireEvent.change(input, { target: { files: [largeFile] } });
+
+        expect(screen.getByText(/exceeds 10MB/)).toBeTruthy();
+    });
+
+    it('auto-generates ID from filename', async () => {
+        render(ImageUpload);
+
+        const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+        const file = createMockFile('My Cool Image.jpg', 1024, 'image/jpeg');
+
+        await fireEvent.change(input, { target: { files: [file] } });
+
+        const idInput = screen.getByPlaceholderText(
+            'e.g. illustration/my-image',
+        ) as HTMLInputElement;
+        expect(idInput.value).toBe('my-cool-image');
+    });
+
+    it('shows duplicate warning when ID already exists', async () => {
+        render(ImageUpload, {
+            props: { existingIds: ['my-image'] },
+        });
+
+        const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+        const file = createMockFile('my-image.jpg', 1024, 'image/jpeg');
+
+        await fireEvent.change(input, { target: { files: [file] } });
+
+        expect(screen.getByText(/already exists/)).toBeTruthy();
+    });
+});

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,18 +1,25 @@
 <script lang="ts">
     import type { Snippet } from 'svelte';
+    import { page } from '$app/state';
     import Header from '$lib/header.svelte';
     import Footer from '$lib/footer.svelte';
     import '../app.css';
 
     let { children }: { children: Snippet } = $props();
+
+    let isAdmin = $derived(page.url.pathname.startsWith('/admin'));
 </script>
 
-<div class="mx-auto flex flex-col h-screen text-gray-600">
-    <Header />
+{#if isAdmin}
+    {@render children()}
+{:else}
+    <div class="mx-auto flex flex-col h-screen text-gray-600">
+        <Header />
 
-    <main class="flex-auto">
-        {@render children()}
-    </main>
+        <main class="flex-auto">
+            {@render children()}
+        </main>
 
-    <Footer />
-</div>
+        <Footer />
+    </div>
+{/if}

--- a/src/routes/admin/+layout.server.ts
+++ b/src/routes/admin/+layout.server.ts
@@ -1,0 +1,10 @@
+import { dev } from '$app/environment';
+import { redirect } from '@sveltejs/kit';
+import type { LayoutServerLoad } from './$types';
+
+export const load: LayoutServerLoad = async () => {
+    if (!dev) {
+        throw redirect(303, '/');
+    }
+    return {};
+};

--- a/src/routes/admin/+layout.svelte
+++ b/src/routes/admin/+layout.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+    import type { Snippet } from 'svelte';
+    import { page } from '$app/state';
+
+    let { children }: { children: Snippet } = $props();
+
+    const navItems = [
+        { label: 'Dashboard', href: '/admin' },
+        { label: 'Images', href: '/admin/images' },
+        { label: 'Collections', href: '/admin/collections' },
+        { label: 'Works', href: '/admin/works' },
+    ];
+
+    function isActive(href: string): boolean {
+        if (href === '/admin') return page.url.pathname === '/admin';
+        return page.url.pathname.startsWith(href);
+    }
+</script>
+
+<div class="flex h-screen bg-gray-50">
+    <aside class="w-56 bg-white border-r border-gray-200 flex flex-col">
+        <div class="p-4 border-b border-gray-200">
+            <h1 class="text-lg font-semibold text-gray-800">Admin</h1>
+        </div>
+
+        <nav class="flex-1 p-2">
+            {#each navItems as item}
+                <a
+                    href={item.href}
+                    class="block px-3 py-2 rounded-md text-sm mb-1 {isActive(item.href)
+                        ? 'bg-blue-50 text-blue-700 font-medium'
+                        : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'}"
+                >
+                    {item.label}
+                </a>
+            {/each}
+        </nav>
+
+        <div class="p-2 border-t border-gray-200">
+            <a
+                href="/"
+                class="block px-3 py-2 rounded-md text-sm text-gray-500 hover:bg-gray-100 hover:text-gray-700"
+            >
+                &larr; Back to site
+            </a>
+        </div>
+    </aside>
+
+    <main class="flex-1 overflow-y-auto p-6">
+        {@render children()}
+    </main>
+</div>

--- a/src/routes/admin/+layout.ts
+++ b/src/routes/admin/+layout.ts
@@ -1,0 +1,2 @@
+export const prerender = false;
+export const ssr = false;

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+    import type { Image, Work } from '$lib/data';
+
+    let images = $state<Image[]>([]);
+    let works = $state<Work[]>([]);
+    let illustrationCount = $state(0);
+    let loading = $state(true);
+    let error = $state<string | null>(null);
+
+    async function loadData() {
+        try {
+            const [imgRes, worksRes, colRes] = await Promise.all([
+                fetch('/api/admin/images'),
+                fetch('/api/admin/works'),
+                fetch('/api/admin/collections'),
+            ]);
+
+            if (!imgRes.ok || !worksRes.ok || !colRes.ok) {
+                throw new Error('Failed to load admin data');
+            }
+
+            const [imgData, worksData, colData] = await Promise.all([
+                imgRes.json(),
+                worksRes.json(),
+                colRes.json(),
+            ]);
+
+            images = imgData.images;
+            works = worksData.works;
+            illustrationCount = colData.collections.illustrations.length;
+        } catch (e) {
+            error = e instanceof Error ? e.message : 'Unknown error';
+        } finally {
+            loading = false;
+        }
+    }
+
+    $effect(() => {
+        loadData();
+    });
+
+    const stats = $derived([
+        { label: 'Total Images', value: images.length, href: '/admin/images' },
+        { label: 'Works', value: works.length, href: '/admin/works' },
+        { label: 'Illustrations', value: illustrationCount, href: '/admin/collections' },
+    ]);
+</script>
+
+<div>
+    <h1 class="text-2xl font-semibold text-gray-800 mb-6">Dashboard</h1>
+
+    {#if loading}
+        <p class="text-gray-500">Loading...</p>
+    {:else if error}
+        <p class="text-red-600">Error: {error}</p>
+    {:else}
+        <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-8">
+            {#each stats as stat}
+                <a
+                    href={stat.href}
+                    class="block bg-white rounded-lg border border-gray-200 p-6 hover:shadow-md transition-shadow"
+                >
+                    <p class="text-sm text-gray-500">{stat.label}</p>
+                    <p class="text-3xl font-bold text-gray-800 mt-1">{stat.value}</p>
+                </a>
+            {/each}
+        </div>
+
+        <h2 class="text-lg font-medium text-gray-700 mb-3">Quick Actions</h2>
+        <div class="flex gap-3">
+            <a
+                href="/admin/images#upload"
+                class="px-4 py-2 bg-blue-600 text-white rounded-md text-sm hover:bg-blue-700 transition-colors"
+            >
+                Upload Image
+            </a>
+            <a
+                href="/admin/images"
+                class="px-4 py-2 bg-white border border-gray-300 text-gray-700 rounded-md text-sm hover:bg-gray-50 transition-colors"
+            >
+                Browse Images
+            </a>
+        </div>
+    {/if}
+</div>

--- a/src/routes/admin/admin-dashboard.test.ts
+++ b/src/routes/admin/admin-dashboard.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import type { Image, Work } from '$lib/data';
+
+function computeStats(images: Image[], works: Work[], illustrationCount: number) {
+    return [
+        { label: 'Total Images', value: images.length, href: '/admin/images' },
+        { label: 'Works', value: works.length, href: '/admin/works' },
+        { label: 'Illustrations', value: illustrationCount, href: '/admin/collections' },
+    ];
+}
+
+describe('Dashboard stats computation', () => {
+    const mockImages: Image[] = [
+        { id: 'img-1', format: 'jpeg', width: 800, height: 600, title: 'Image 1' },
+        { id: 'img-2', format: 'png', width: 1200, height: 800, title: 'Image 2' },
+        { id: 'img-3', format: 'jpeg', width: 640, height: 480, title: 'Image 3' },
+    ];
+
+    const mockWorks: Work[] = [
+        { id: 'work-1', title: 'Work 1', images: ['img-1'] },
+        { id: 'work-2', title: 'Work 2', images: ['img-2', 'img-3'] },
+    ];
+
+    it('computes correct counts', () => {
+        const stats = computeStats(mockImages, mockWorks, 5);
+
+        expect(stats[0]!.label).toBe('Total Images');
+        expect(stats[0]!.value).toBe(3);
+        expect(stats[1]!.label).toBe('Works');
+        expect(stats[1]!.value).toBe(2);
+        expect(stats[2]!.label).toBe('Illustrations');
+        expect(stats[2]!.value).toBe(5);
+    });
+
+    it('handles empty data', () => {
+        const stats = computeStats([], [], 0);
+
+        expect(stats[0]!.value).toBe(0);
+        expect(stats[1]!.value).toBe(0);
+        expect(stats[2]!.value).toBe(0);
+    });
+
+    it('includes correct navigation links', () => {
+        const stats = computeStats(mockImages, mockWorks, 5);
+
+        expect(stats[0]!.href).toBe('/admin/images');
+        expect(stats[1]!.href).toBe('/admin/works');
+        expect(stats[2]!.href).toBe('/admin/collections');
+    });
+});

--- a/src/routes/admin/collections/+page.svelte
+++ b/src/routes/admin/collections/+page.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+</script>
+
+<div>
+    <h1 class="text-2xl font-semibold text-gray-800 mb-6">Collections</h1>
+    <p class="text-gray-500">Collections management coming soon.</p>
+</div>

--- a/src/routes/admin/images/+page.svelte
+++ b/src/routes/admin/images/+page.svelte
@@ -1,0 +1,176 @@
+<script lang="ts">
+    import type { Image } from '$lib/data';
+    import ImageThumbnail from '$lib/admin/image-thumbnail.svelte';
+    import ImageUpload from '$lib/admin/image-upload.svelte';
+    import {
+        filterImages,
+        extractPrefixes,
+        buildImageUsageMap,
+        type Collections,
+        type ImageUsage,
+    } from '$lib/admin/image-filter';
+
+    const PAGE_SIZE = 24;
+
+    let allImages = $state<Image[]>([]);
+    let collections = $state<Collections | null>(null);
+    let loading = $state(true);
+    let error = $state<string | null>(null);
+    let searchQuery = $state('');
+    let currentPage = $state(0);
+
+    let usageMap = $derived(
+        collections ? buildImageUsageMap(collections) : new Map<string, ImageUsage[]>(),
+    );
+
+    let filteredImages = $derived(filterImages(allImages, searchQuery));
+    let prefixes = $derived(extractPrefixes(allImages));
+    let totalPages = $derived(Math.ceil(filteredImages.length / PAGE_SIZE));
+    let displayedImages = $derived(
+        filteredImages.slice(currentPage * PAGE_SIZE, (currentPage + 1) * PAGE_SIZE),
+    );
+    let existingIds = $derived(allImages.map((img) => img.id));
+
+    $effect(() => {
+        // Reset page when filter changes
+        searchQuery;
+        currentPage = 0;
+    });
+
+    async function loadData() {
+        try {
+            const [imgRes, colRes] = await Promise.all([
+                fetch('/api/admin/images'),
+                fetch('/api/admin/collections'),
+            ]);
+
+            if (!imgRes.ok || !colRes.ok) {
+                throw new Error('Failed to load data');
+            }
+
+            const [imgData, colData] = await Promise.all([imgRes.json(), colRes.json()]);
+            allImages = imgData.images;
+            collections = colData.collections;
+        } catch (e) {
+            error = e instanceof Error ? e.message : 'Unknown error';
+        } finally {
+            loading = false;
+        }
+    }
+
+    $effect(() => {
+        loadData();
+    });
+
+    function handleUploadSuccess(image: Image) {
+        allImages = [image, ...allImages];
+    }
+
+    async function handleDelete(id: string) {
+        if (!confirm(`Delete image "${id}"? This cannot be undone.`)) return;
+
+        try {
+            const res = await fetch(`/api/admin/images/${id}`, { method: 'DELETE' });
+            if (!res.ok) throw new Error(`Delete failed (${res.status})`);
+            allImages = allImages.filter((img) => img.id !== id);
+        } catch (e) {
+            alert(e instanceof Error ? e.message : 'Delete failed');
+        }
+    }
+
+    function setFilter(prefix: string) {
+        searchQuery = prefix === '(root)' ? '' : prefix + '/';
+    }
+</script>
+
+<div>
+    <h1 class="text-2xl font-semibold text-gray-800 mb-6">Images</h1>
+
+    <section id="upload" class="mb-8">
+        <h2 class="text-lg font-medium text-gray-700 mb-3">Upload New Image</h2>
+        <ImageUpload {existingIds} onsuccess={handleUploadSuccess} />
+    </section>
+
+    {#if loading}
+        <p class="text-gray-500">Loading images...</p>
+    {:else if error}
+        <p class="text-red-600">Error: {error}</p>
+    {:else}
+        <section>
+            <div class="flex flex-col sm:flex-row sm:items-center gap-3 mb-4">
+                <input
+                    type="text"
+                    bind:value={searchQuery}
+                    placeholder="Search by image ID..."
+                    class="border border-gray-300 rounded px-3 py-1.5 text-sm flex-1 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                />
+                <span class="text-sm text-gray-500">
+                    {filteredImages.length} image{filteredImages.length !== 1 ? 's' : ''}
+                </span>
+            </div>
+
+            {#if prefixes.length > 1}
+                <div class="flex flex-wrap gap-1.5 mb-4">
+                    <button
+                        type="button"
+                        class="px-2 py-0.5 text-xs rounded border {searchQuery === ''
+                            ? 'bg-blue-100 border-blue-300 text-blue-700'
+                            : 'bg-white border-gray-200 text-gray-600 hover:bg-gray-50'}"
+                        onclick={() => { searchQuery = ''; }}
+                    >
+                        All
+                    </button>
+                    {#each prefixes as prefix}
+                        <button
+                            type="button"
+                            class="px-2 py-0.5 text-xs rounded border {searchQuery === prefix + '/' || (prefix === '(root)' && searchQuery === '')
+                                ? 'bg-blue-100 border-blue-300 text-blue-700'
+                                : 'bg-white border-gray-200 text-gray-600 hover:bg-gray-50'}"
+                            onclick={() => setFilter(prefix)}
+                        >
+                            {prefix}
+                        </button>
+                    {/each}
+                </div>
+            {/if}
+
+            <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
+                {#each displayedImages as image (image.id)}
+                    <ImageThumbnail
+                        {image}
+                        usages={usageMap.get(image.id) ?? []}
+                        ondelete={handleDelete}
+                    />
+                {/each}
+            </div>
+
+            {#if filteredImages.length === 0}
+                <p class="text-center text-gray-400 py-8">No images match your search.</p>
+            {/if}
+
+            {#if totalPages > 1}
+                <div class="flex items-center justify-center gap-2 mt-6">
+                    <button
+                        type="button"
+                        class="px-3 py-1 text-sm rounded border border-gray-300 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-50"
+                        disabled={currentPage === 0}
+                        onclick={() => { currentPage = currentPage - 1; }}
+                    >
+                        Previous
+                    </button>
+                    <span class="text-sm text-gray-600">
+                        Page {currentPage + 1} of {totalPages}
+                    </span>
+                    <button
+                        type="button"
+                        class="px-3 py-1 text-sm rounded border border-gray-300 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-50"
+                        disabled={currentPage >= totalPages - 1}
+                        onclick={() => { currentPage = currentPage + 1; }}
+                    >
+                        Next
+                    </button>
+                </div>
+            {/if}
+        </section>
+    {/if}
+</div>

--- a/src/routes/admin/works/+page.svelte
+++ b/src/routes/admin/works/+page.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+</script>
+
+<div>
+    <h1 class="text-2xl font-semibold text-gray-800 mb-6">Works</h1>
+    <p class="text-gray-500">Works management coming soon.</p>
+</div>

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -23,22 +23,27 @@ Object.defineProperty(window, 'matchMedia', {
     disconnect: vi.fn(),
 }));
 
-// Mock document methods for image preloading
-Object.defineProperty(document, 'head', {
-    writable: true,
-    value: {
-        appendChild: vi.fn(),
-    },
+// Mock document.head.appendChild for image preloading (preserve original for DOM operations)
+const originalHeadAppendChild = document.head.appendChild.bind(document.head);
+document.head.appendChild = vi.fn().mockImplementation((node: Node) => {
+    return originalHeadAppendChild(node);
 });
 
-Object.defineProperty(document, 'createElement', {
-    writable: true,
-    value: vi.fn().mockReturnValue({
-        rel: '',
-        as: '',
-        href: '',
-    }),
-});
+// Wrap document.createElement to support preloading mocks while preserving DOM functionality
+const originalCreateElement = document.createElement.bind(document);
+document.createElement = vi
+    .fn()
+    .mockImplementation((tagName: string, options?: ElementCreationOptions) => {
+        return originalCreateElement(tagName, options);
+    }) as unknown as typeof document.createElement;
+
+// Mock URL.createObjectURL/revokeObjectURL for file preview
+if (typeof URL.createObjectURL === 'undefined') {
+    URL.createObjectURL = vi.fn().mockReturnValue('blob:mock-url');
+}
+if (typeof URL.revokeObjectURL === 'undefined') {
+    URL.revokeObjectURL = vi.fn();
+}
 
 // Mock ResizeObserver
 (global as any).ResizeObserver = vi.fn().mockImplementation(() => ({

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,4 +8,7 @@ export default defineConfig({
         globals: true,
         setupFiles: ['./src/test-setup.ts'],
     },
+    resolve: {
+        conditions: ['browser'],
+    },
 });


### PR DESCRIPTION
Build the admin interface for browsing images and uploading new ones:
- Admin layout with sidebar navigation (dev-mode guard redirects to / in production)
- Dashboard with summary stats and quick links
- Image gallery with search/filter by ID prefix, pagination (24/page)
- Thumbnails show collection usage labels as links; delete disabled for used images
- Drag-and-drop upload with client-side validation, preview, and auto-generated IDs
- 25 new tests (93 total): filter utilities, thumbnail component, upload component, dashboard stats
- Fix vitest config for Svelte 5 component testing (browser resolve condition)
- Fix test-setup.ts to preserve DOM operations while supporting preload mocks

https://claude.ai/code/session_017g3ZRVQuj9xz7AwnX8demh