### PR TITLE
Add D1 database support with JSON fallback for data persistence

### DIFF
--- a/migrations/0001_initial_schema.sql
+++ b/migrations/0001_initial_schema.sql
@@ -1,0 +1,40 @@
+-- Phase 5: Initial D1 schema for sasage-web
+-- Migrates data from images.json + collections.json to Cloudflare D1
+
+CREATE TABLE images (
+  id TEXT PRIMARY KEY,
+  format TEXT NOT NULL,
+  width INTEGER NOT NULL,
+  height INTEGER NOT NULL,
+  title TEXT,
+  title_ja TEXT,
+  description TEXT,
+  description_ja TEXT,
+  sha1 TEXT,
+  created_at TEXT DEFAULT (datetime('now'))
+);
+
+CREATE TABLE collections (
+  name TEXT NOT NULL,
+  image_id TEXT NOT NULL,
+  position INTEGER NOT NULL,
+  PRIMARY KEY (name, image_id)
+);
+
+CREATE TABLE works (
+  id TEXT PRIMARY KEY,
+  cover_image_id TEXT,
+  title TEXT NOT NULL,
+  title_ja TEXT,
+  subtitle TEXT,
+  subtitle_ja TEXT,
+  position INTEGER NOT NULL
+);
+
+CREATE TABLE work_images (
+  work_id TEXT NOT NULL,
+  image_id TEXT NOT NULL,
+  position INTEGER NOT NULL,
+  PRIMARY KEY (work_id, image_id),
+  FOREIGN KEY (work_id) REFERENCES works(id)
+);

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
         "format": "prettier --ignore-path .gitignore --ignore-path .prettierignore --write ."
     },
     "devDependencies": {
+        "@cloudflare/workers-types": "^4.20260414.1",
         "@playwright/test": "^1.58.1",
         "@sveltejs/adapter-cloudflare": "^7.2.6",
         "@sveltejs/kit": "^2.50.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,12 +11,15 @@ importers:
 
   .:
     devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20260414.1
+        version: 4.20260414.1
       '@playwright/test':
         specifier: ^1.58.1
         version: 1.58.1
       '@sveltejs/adapter-cloudflare':
         specifier: ^7.2.6
-        version: 7.2.6(@sveltejs/kit@2.50.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.49.1)(vite@5.4.21(@types/node@24.10.9)))(svelte@5.49.1)(typescript@5.9.3)(vite@5.4.21(@types/node@24.10.9)))(wrangler@4.61.1(@cloudflare/workers-types@4.20260130.0))
+        version: 7.2.6(@sveltejs/kit@2.50.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.49.1)(vite@5.4.21(@types/node@24.10.9)))(svelte@5.49.1)(typescript@5.9.3)(vite@5.4.21(@types/node@24.10.9)))(wrangler@4.61.1(@cloudflare/workers-types@4.20260414.1))
       '@sveltejs/kit':
         specifier: ^2.50.1
         version: 2.50.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.49.1)(vite@5.4.21(@types/node@24.10.9)))(svelte@5.49.1)(typescript@5.9.3)(vite@5.4.21(@types/node@24.10.9))
@@ -193,8 +196,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@cloudflare/workers-types@4.20260130.0':
-    resolution: {integrity: sha512-eVJZjA4o0ANE/RX5g6mBs5MKRQxcSJYDPsFj8SPul7FDSFv682UzwXK3i0CSdIy/rtDNrMRmwJZ8KxANg2bY8A==}
+  '@cloudflare/workers-types@4.20260414.1':
+    resolution: {integrity: sha512-E2wgYT1ywoM1M68nmVpxKdKzXsZm5vOu2plsqUixlK7YIydqsw31dZ+EjwXnAsdEjLaYC6XfsJayil8AEhyaBQ==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -609,89 +612,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -798,66 +817,79 @@ packages:
     resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.57.1':
     resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.57.1':
     resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.57.1':
     resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.57.1':
     resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.57.1':
     resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.57.1':
     resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.57.1':
     resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.57.1':
     resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.57.1':
     resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.57.1':
     resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.57.1':
     resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.57.1':
     resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.57.1':
     resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
@@ -2832,7 +2864,7 @@ snapshots:
   '@cloudflare/workerd-windows-64@1.20260128.0':
     optional: true
 
-  '@cloudflare/workers-types@4.20260130.0': {}
+  '@cloudflare/workers-types@4.20260414.1': {}
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -3304,12 +3336,12 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
-  '@sveltejs/adapter-cloudflare@7.2.6(@sveltejs/kit@2.50.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.49.1)(vite@5.4.21(@types/node@24.10.9)))(svelte@5.49.1)(typescript@5.9.3)(vite@5.4.21(@types/node@24.10.9)))(wrangler@4.61.1(@cloudflare/workers-types@4.20260130.0))':
+  '@sveltejs/adapter-cloudflare@7.2.6(@sveltejs/kit@2.50.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.49.1)(vite@5.4.21(@types/node@24.10.9)))(svelte@5.49.1)(typescript@5.9.3)(vite@5.4.21(@types/node@24.10.9)))(wrangler@4.61.1(@cloudflare/workers-types@4.20260414.1))':
     dependencies:
-      '@cloudflare/workers-types': 4.20260130.0
+      '@cloudflare/workers-types': 4.20260414.1
       '@sveltejs/kit': 2.50.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.49.1)(vite@5.4.21(@types/node@24.10.9)))(svelte@5.49.1)(typescript@5.9.3)(vite@5.4.21(@types/node@24.10.9))
       worktop: 0.8.0-next.18
-      wrangler: 4.61.1(@cloudflare/workers-types@4.20260130.0)
+      wrangler: 4.61.1(@cloudflare/workers-types@4.20260414.1)
 
   '@sveltejs/kit@2.50.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.49.1)(vite@5.4.21(@types/node@24.10.9)))(svelte@5.49.1)(typescript@5.9.3)(vite@5.4.21(@types/node@24.10.9))':
     dependencies:
@@ -5176,7 +5208,7 @@ snapshots:
       mrmime: 2.0.1
       regexparam: 3.0.0
 
-  wrangler@4.61.1(@cloudflare/workers-types@4.20260130.0):
+  wrangler@4.61.1(@cloudflare/workers-types@4.20260414.1):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@cloudflare/unenv-preset': 2.12.0(unenv@2.0.0-rc.24)(workerd@1.20260128.0)
@@ -5187,7 +5219,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       workerd: 1.20260128.0
     optionalDependencies:
-      '@cloudflare/workers-types': 4.20260130.0
+      '@cloudflare/workers-types': 4.20260414.1
       fsevents: 2.3.3
     transitivePeerDependencies:
       - bufferutil

--- a/scripts/migrate-to-d1.ts
+++ b/scripts/migrate-to-d1.ts
@@ -60,7 +60,8 @@ function extractText(ts: string | TranslatableString | undefined): {
     return { text: ts.en ?? null, text_ja: ts.ja ?? null };
 }
 
-const root = join(import.meta.dirname ?? process.cwd(), '..');
+const scriptDir = import.meta.dirname ?? new URL('.', import.meta.url).pathname;
+const root = join(scriptDir, '..');
 const imagesRaw = readFileSync(join(root, 'src', 'images.json'), 'utf-8');
 const collectionsRaw = readFileSync(join(root, 'src', 'collections.json'), 'utf-8');
 

--- a/scripts/migrate-to-d1.ts
+++ b/scripts/migrate-to-d1.ts
@@ -1,0 +1,129 @@
+/**
+ * Migration script: JSON files → D1 SQL
+ *
+ * Reads src/images.json and src/collections.json, outputs SQL INSERT statements
+ * that can be applied to a D1 database.
+ *
+ * Usage:
+ *   npx tsx scripts/migrate-to-d1.ts > migrations/0002_seed_data.sql
+ *   wrangler d1 execute sasage-web-db --local --file=migrations/0002_seed_data.sql
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+interface TranslatableString {
+    en?: string;
+    ja?: string;
+}
+
+interface ImageEntry {
+    id: string;
+    format: string;
+    width: number;
+    height: number;
+    title: string | TranslatableString;
+    description?: string | TranslatableString;
+    sha1?: string;
+}
+
+interface Work {
+    id: string;
+    image?: string;
+    title: string | TranslatableString;
+    subtitle?: string | TranslatableString;
+    images: string[];
+}
+
+interface CollectionsData {
+    topImages: string[];
+    topImagesWide: string[];
+    works: Work[];
+    illustrations: string[];
+}
+
+function escapeSQL(value: string): string {
+    return value.replace(/'/g, "''");
+}
+
+function sqlString(value: string | null | undefined): string {
+    if (value == null) return 'NULL';
+    return `'${escapeSQL(value)}'`;
+}
+
+function extractText(ts: string | TranslatableString | undefined): {
+    text: string | null;
+    text_ja: string | null;
+} {
+    if (ts === undefined) return { text: null, text_ja: null };
+    if (typeof ts === 'string') return { text: ts, text_ja: null };
+    return { text: ts.en ?? null, text_ja: ts.ja ?? null };
+}
+
+const root = join(import.meta.dirname ?? process.cwd(), '..');
+const imagesRaw = readFileSync(join(root, 'src', 'images.json'), 'utf-8');
+const collectionsRaw = readFileSync(join(root, 'src', 'collections.json'), 'utf-8');
+
+const images: Record<string, ImageEntry> = JSON.parse(imagesRaw);
+const collections: CollectionsData = JSON.parse(collectionsRaw);
+
+const lines: string[] = [];
+
+lines.push('-- Auto-generated migration: JSON → D1');
+lines.push('-- Source: src/images.json + src/collections.json');
+lines.push('');
+
+// --- Images ---
+lines.push('-- Images');
+for (const img of Object.values(images)) {
+    const { text: title, text_ja: titleJa } = extractText(img.title);
+    const { text: desc, text_ja: descJa } = extractText(img.description);
+    lines.push(
+        `INSERT INTO images (id, format, width, height, title, title_ja, description, description_ja, sha1) VALUES (${sqlString(img.id)}, ${sqlString(img.format)}, ${img.width}, ${img.height}, ${sqlString(title)}, ${sqlString(titleJa)}, ${sqlString(desc)}, ${sqlString(descJa)}, ${sqlString(img.sha1)});`,
+    );
+}
+
+lines.push('');
+
+// --- Collections ---
+lines.push('-- Collections');
+function addCollection(name: string, ids: string[]) {
+    for (let i = 0; i < ids.length; i++) {
+        lines.push(
+            `INSERT INTO collections (name, image_id, position) VALUES (${sqlString(name)}, ${sqlString(ids[i])}, ${i});`,
+        );
+    }
+}
+
+addCollection('topImages', collections.topImages);
+addCollection('topImagesWide', collections.topImagesWide);
+addCollection('illustrations', collections.illustrations);
+
+lines.push('');
+
+// --- Works ---
+lines.push('-- Works');
+for (let wi = 0; wi < collections.works.length; wi++) {
+    const work = collections.works[wi]!;
+    const { text: title, text_ja: titleJa } = extractText(work.title);
+    const { text: subtitle, text_ja: subtitleJa } = extractText(work.subtitle);
+    lines.push(
+        `INSERT INTO works (id, cover_image_id, title, title_ja, subtitle, subtitle_ja, position) VALUES (${sqlString(work.id)}, ${sqlString(work.image)}, ${sqlString(title)}, ${sqlString(titleJa)}, ${sqlString(subtitle)}, ${sqlString(subtitleJa)}, ${wi});`,
+    );
+}
+
+lines.push('');
+
+// --- Work Images ---
+lines.push('-- Work Images');
+for (const work of collections.works) {
+    for (let ii = 0; ii < work.images.length; ii++) {
+        lines.push(
+            `INSERT INTO work_images (work_id, image_id, position) VALUES (${sqlString(work.id)}, ${sqlString(work.images[ii])}, ${ii});`,
+        );
+    }
+}
+
+lines.push('');
+
+console.log(lines.join('\n'));

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -9,7 +9,11 @@ declare namespace App {
         lang: Lang;
     }
 
-    // interface Platform {}
+    interface Platform {
+        env?: {
+            DB?: import('$lib/server/d1-types').D1Database;
+        };
+    }
 
     // interface Stuff {}
 }

--- a/src/lib/server/admin-api.test.ts
+++ b/src/lib/server/admin-api.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { RequestEvent } from '@sveltejs/kit';
 import type { ImageSet } from '$lib/data';
-import type { Collections } from '$lib/server/data-store';
+import type { Collections, DataStore } from '$lib/server/data-store';
 
 // Mock $app/environment
 vi.mock('$app/environment', () => ({ dev: true }));
@@ -19,12 +19,9 @@ vi.mock('$lib/server/admin-guard', async (importOriginal) => {
     };
 });
 
-// Mock data-store
+// Mock data-store — mock getDataStore factory
 vi.mock('$lib/server/data-store', () => ({
-    readImages: vi.fn(),
-    writeImages: vi.fn(),
-    readCollections: vi.fn(),
-    writeCollections: vi.fn(),
+    getDataStore: vi.fn(),
 }));
 
 // Mock cloudflare-images
@@ -35,7 +32,7 @@ vi.mock('$lib/server/cloudflare-images', () => ({
     computeSha1: vi.fn(),
 }));
 
-import { readImages, writeImages, readCollections, writeCollections } from '$lib/server/data-store';
+import { getDataStore } from '$lib/server/data-store';
 import {
     uploadImage,
     deleteImage as deleteCloudflareImage,
@@ -93,6 +90,15 @@ const mockCollections: Collections = {
         },
     ],
     illustrations: ['test/image-2'],
+};
+
+// --- Mock store ---
+
+let mockStore: {
+    readImages: ReturnType<typeof vi.fn>;
+    writeImages: ReturnType<typeof vi.fn>;
+    readCollections: ReturnType<typeof vi.fn>;
+    writeCollections: ReturnType<typeof vi.fn>;
 };
 
 // --- Helpers ---
@@ -155,8 +161,14 @@ async function expectHttpError(fn: () => unknown, status: number): Promise<void>
 
 beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(readImages).mockReturnValue(structuredClone(mockImages));
-    vi.mocked(readCollections).mockReturnValue(structuredClone(mockCollections));
+
+    mockStore = {
+        readImages: vi.fn().mockResolvedValue(structuredClone(mockImages)),
+        writeImages: vi.fn().mockResolvedValue(undefined),
+        readCollections: vi.fn().mockResolvedValue(structuredClone(mockCollections)),
+        writeCollections: vi.fn().mockResolvedValue(undefined),
+    };
+    vi.mocked(getDataStore).mockReturnValue(mockStore as unknown as DataStore);
 });
 
 describe('Images API - list', () => {
@@ -185,7 +197,7 @@ describe('Images API - list', () => {
         expect(data.image.id).toBe('new/image');
         expect(data.image.title).toBe('New Image');
         expect(data.image.format).toBe('jpeg');
-        expect(writeImages).toHaveBeenCalledTimes(1);
+        expect(mockStore.writeImages).toHaveBeenCalledTimes(1);
     });
 
     it('POST returns 400 when file is missing', async () => {
@@ -234,7 +246,7 @@ describe('Images API - single', () => {
         expect(res.status).toBe(200);
         expect(data.image.title).toBe('Updated Title');
         expect(data.image.description).toBe('A description');
-        expect(writeImages).toHaveBeenCalledTimes(1);
+        expect(mockStore.writeImages).toHaveBeenCalledTimes(1);
     });
 
     it('PATCH returns 404 for non-existent image', async () => {
@@ -262,10 +274,10 @@ describe('Images API - single', () => {
             { accountId: 'test-account', apiToken: 'test-token' },
             'test/image-1',
         );
-        expect(writeImages).toHaveBeenCalledTimes(1);
+        expect(mockStore.writeImages).toHaveBeenCalledTimes(1);
 
         // Verify collections were cleaned up
-        const writtenCollections = vi.mocked(writeCollections).mock.calls[0]![0];
+        const writtenCollections = mockStore.writeCollections.mock.calls[0]![0] as Collections;
         expect(writtenCollections.topImages).toEqual([]);
         expect(writtenCollections.works[0]!.images).toEqual(['test/image-2']);
         expect(writtenCollections.works[0]!.image).toBeUndefined();
@@ -278,7 +290,7 @@ describe('Images API - single', () => {
             () => imageDELETE(mockEvent({ params: { id: 'test/image-1' } })),
             502,
         );
-        expect(writeImages).not.toHaveBeenCalled();
+        expect(mockStore.writeImages).not.toHaveBeenCalled();
     });
 
     it('DELETE returns 404 for non-existent image', async () => {
@@ -309,7 +321,7 @@ describe('Collections API', () => {
         expect(res.status).toBe(200);
         expect(data.collections.topImages).toEqual(['img-a', 'img-b']);
         expect(data.collections.illustrations).toEqual(['img-c']);
-        expect(writeCollections).toHaveBeenCalledTimes(1);
+        expect(mockStore.writeCollections).toHaveBeenCalledTimes(1);
     });
 
     it('PATCH returns 400 for invalid field type', async () => {
@@ -366,7 +378,7 @@ describe('Works API - list', () => {
         expect(data.work.id).toBe('new-work');
         expect(data.work.title.en).toBe('New Work');
         expect(data.work.images).toEqual(['img-1', 'img-2']);
-        expect(writeCollections).toHaveBeenCalledTimes(1);
+        expect(mockStore.writeCollections).toHaveBeenCalledTimes(1);
     });
 
     it('POST returns 400 when id is missing', async () => {
@@ -404,7 +416,7 @@ describe('Works API - single', () => {
         expect(res.status).toBe(200);
         expect(data.work.title).toBe('Updated Work');
         expect(data.work.images).toEqual(['img-new']);
-        expect(writeCollections).toHaveBeenCalledTimes(1);
+        expect(mockStore.writeCollections).toHaveBeenCalledTimes(1);
     });
 
     it('PATCH returns 404 for non-existent work', async () => {
@@ -426,7 +438,7 @@ describe('Works API - single', () => {
         expect(res.status).toBe(200);
         expect(data.success).toBe(true);
 
-        const writtenCollections = vi.mocked(writeCollections).mock.calls[0]![0];
+        const writtenCollections = mockStore.writeCollections.mock.calls[0]![0] as Collections;
         expect(writtenCollections.works).toHaveLength(0);
     });
 

--- a/src/lib/server/d1-data-store.test.ts
+++ b/src/lib/server/d1-data-store.test.ts
@@ -1,0 +1,468 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { D1DataStore, getDataStore, JsonDataStore } from './data-store';
+import type { Collections } from './data-store';
+import type { ImageSet } from '../data';
+import type { D1Database, D1PreparedStatement, D1Result, D1ExecResult } from './d1-types';
+
+// --- In-memory D1 mock ---
+// Simulates D1Database with in-memory storage using simple SQL parsing
+
+interface TableRow {
+    [key: string]: string | number | null;
+}
+
+function createMockD1(): D1Database {
+    const tables: Record<string, TableRow[]> = {
+        images: [],
+        collections: [],
+        works: [],
+        work_images: [],
+    };
+
+    function parseInsert(sql: string, bindings: unknown[]): void {
+        const tableMatch = sql.match(/INSERT INTO (\w+)/i);
+        if (!tableMatch) throw new Error(`Cannot parse INSERT: ${sql}`);
+        const table = tableMatch[1]!;
+
+        const colsMatch = sql.match(/\(([^)]+)\)\s*VALUES/i);
+        if (!colsMatch) throw new Error(`Cannot parse columns: ${sql}`);
+        const cols = colsMatch[1]!.split(',').map((c) => c.trim());
+
+        const row: TableRow = {};
+        for (let i = 0; i < cols.length; i++) {
+            row[cols[i]!] = bindings[i] as string | number | null;
+        }
+
+        if (!tables[table]) tables[table] = [];
+        tables[table]!.push(row);
+    }
+
+    function parseDelete(sql: string): void {
+        const tableMatch = sql.match(/DELETE FROM (\w+)/i);
+        if (!tableMatch) throw new Error(`Cannot parse DELETE: ${sql}`);
+        const table = tableMatch[1]!;
+        tables[table] = [];
+    }
+
+    function parseSelect(sql: string): TableRow[] {
+        const tableMatch = sql.match(/FROM (\w+)/i);
+        if (!tableMatch) throw new Error(`Cannot parse SELECT: ${sql}`);
+        const table = tableMatch[1]!;
+
+        const rows = [...(tables[table] ?? [])];
+
+        const orderMatch = sql.match(/ORDER BY (\w+)/i);
+        if (orderMatch) {
+            const col = orderMatch[1]!;
+            rows.sort((a, b) => {
+                const va = a[col];
+                const vb = b[col];
+                if (typeof va === 'number' && typeof vb === 'number') return va - vb;
+                return String(va ?? '').localeCompare(String(vb ?? ''));
+            });
+        }
+
+        return rows;
+    }
+
+    function createStatement(sql: string, boundValues: unknown[] = []): D1PreparedStatement {
+        const stmt: D1PreparedStatement = {
+            bind(...values: unknown[]) {
+                // D1's bind() returns a NEW statement with bindings applied
+                return createStatement(sql, values);
+            },
+            async first<T>(): Promise<T | null> {
+                const results = parseSelect(sql);
+                return (results[0] as T) ?? null;
+            },
+            async all<T>(): Promise<D1Result<T>> {
+                if (sql.trim().toUpperCase().startsWith('SELECT')) {
+                    const results = parseSelect(sql);
+                    return { results: results as T[], success: true, meta: {} as D1ExecResult };
+                }
+                if (sql.trim().toUpperCase().startsWith('INSERT')) {
+                    parseInsert(sql, boundValues);
+                    return { results: [], success: true, meta: {} as D1ExecResult };
+                }
+                if (sql.trim().toUpperCase().startsWith('DELETE')) {
+                    parseDelete(sql);
+                    return { results: [], success: true, meta: {} as D1ExecResult };
+                }
+                return { results: [], success: true, meta: {} as D1ExecResult };
+            },
+            async run(): Promise<D1ExecResult> {
+                if (sql.trim().toUpperCase().startsWith('INSERT')) {
+                    parseInsert(sql, boundValues);
+                } else if (sql.trim().toUpperCase().startsWith('DELETE')) {
+                    parseDelete(sql);
+                }
+                return {} as D1ExecResult;
+            },
+            async raw<T>(): Promise<T[]> {
+                return [];
+            },
+        } as D1PreparedStatement;
+
+        return stmt;
+    }
+
+    return {
+        prepare(sql: string) {
+            return createStatement(sql);
+        },
+        async batch<T>(statements: D1PreparedStatement[]): Promise<D1Result<T>[]> {
+            const results: D1Result<T>[] = [];
+            for (const stmt of statements) {
+                const result = await stmt.all<T>();
+                results.push(result);
+            }
+            return results;
+        },
+        async exec(sql: string): Promise<D1ExecResult> {
+            const stmts = sql.split(';').filter((s) => s.trim());
+            for (const s of stmts) {
+                const trimmed = s.trim().toUpperCase();
+                if (trimmed.startsWith('DELETE')) {
+                    parseDelete(s);
+                }
+            }
+            return {} as D1ExecResult;
+        },
+        async dump(): Promise<ArrayBuffer> {
+            return new ArrayBuffer(0);
+        },
+    } as D1Database;
+}
+
+// --- Tests ---
+
+describe('D1DataStore', () => {
+    let db: D1Database;
+    let store: D1DataStore;
+
+    beforeEach(() => {
+        db = createMockD1();
+        store = new D1DataStore(db);
+    });
+
+    describe('readImages', () => {
+        it('returns empty ImageSet when no images exist', async () => {
+            const images = await store.readImages();
+            expect(Object.keys(images)).toHaveLength(0);
+        });
+
+        it('returns images after writeImages', async () => {
+            const input: ImageSet = {
+                'test/1': {
+                    id: 'test/1',
+                    format: 'jpeg',
+                    width: 800,
+                    height: 600,
+                    title: 'Test Image',
+                },
+            };
+
+            await store.writeImages(input);
+            const result = await store.readImages();
+
+            expect(Object.keys(result)).toHaveLength(1);
+            expect(result['test/1']?.id).toBe('test/1');
+            expect(result['test/1']?.format).toBe('jpeg');
+            expect(result['test/1']?.width).toBe(800);
+            expect(result['test/1']?.height).toBe(600);
+            expect(result['test/1']?.title).toBe('Test Image');
+        });
+
+        it('handles bilingual title', async () => {
+            const input: ImageSet = {
+                'test/bi': {
+                    id: 'test/bi',
+                    format: 'png',
+                    width: 100,
+                    height: 100,
+                    title: { en: 'English', ja: '日本語' },
+                },
+            };
+
+            await store.writeImages(input);
+            const result = await store.readImages();
+
+            expect(result['test/bi']?.title).toEqual({ en: 'English', ja: '日本語' });
+        });
+
+        it('handles image with description', async () => {
+            const input: ImageSet = {
+                'test/desc': {
+                    id: 'test/desc',
+                    format: 'jpeg',
+                    width: 100,
+                    height: 100,
+                    title: 'Has Description',
+                    description: { en: 'Desc EN', ja: 'Desc JA' },
+                },
+            };
+
+            await store.writeImages(input);
+            const result = await store.readImages();
+
+            expect(result['test/desc']?.description).toEqual({ en: 'Desc EN', ja: 'Desc JA' });
+        });
+
+        it('omits description when not present', async () => {
+            const input: ImageSet = {
+                'test/nodesc': {
+                    id: 'test/nodesc',
+                    format: 'jpeg',
+                    width: 100,
+                    height: 100,
+                    title: 'No Description',
+                },
+            };
+
+            await store.writeImages(input);
+            const result = await store.readImages();
+
+            expect(result['test/nodesc']?.description).toBeUndefined();
+        });
+    });
+
+    describe('writeImages', () => {
+        it('replaces all images on write', async () => {
+            const first: ImageSet = {
+                a: { id: 'a', format: 'jpeg', width: 1, height: 1, title: 'A' },
+                b: { id: 'b', format: 'png', width: 2, height: 2, title: 'B' },
+            };
+            await store.writeImages(first);
+
+            const second: ImageSet = {
+                c: { id: 'c', format: 'jpeg', width: 3, height: 3, title: 'C' },
+            };
+            await store.writeImages(second);
+
+            const result = await store.readImages();
+            expect(Object.keys(result)).toHaveLength(1);
+            expect(result['c']?.id).toBe('c');
+            expect(result['a']).toBeUndefined();
+        });
+    });
+
+    describe('readCollections', () => {
+        it('returns empty collections when no data exists', async () => {
+            const collections = await store.readCollections();
+            expect(collections.topImages).toEqual([]);
+            expect(collections.topImagesWide).toEqual([]);
+            expect(collections.works).toEqual([]);
+            expect(collections.illustrations).toEqual([]);
+        });
+
+        it('returns collections after writeCollections', async () => {
+            const input: Collections = {
+                topImages: ['img-1', 'img-2'],
+                topImagesWide: ['wide-1'],
+                works: [
+                    {
+                        id: 'work-1',
+                        image: 'cover-1',
+                        title: 'Work Title',
+                        images: ['img-a', 'img-b'],
+                    },
+                ],
+                illustrations: ['ill-1', 'ill-2', 'ill-3'],
+            };
+
+            await store.writeCollections(input);
+            const result = await store.readCollections();
+
+            expect(result.topImages).toEqual(['img-1', 'img-2']);
+            expect(result.topImagesWide).toEqual(['wide-1']);
+            expect(result.illustrations).toEqual(['ill-1', 'ill-2', 'ill-3']);
+            expect(result.works).toHaveLength(1);
+            expect(result.works[0]!.id).toBe('work-1');
+            expect(result.works[0]!.image).toBe('cover-1');
+            expect(result.works[0]!.title).toBe('Work Title');
+            expect(result.works[0]!.images).toEqual(['img-a', 'img-b']);
+        });
+    });
+
+    describe('writeCollections', () => {
+        it('preserves position ordering', async () => {
+            const input: Collections = {
+                topImages: ['third', 'first', 'second'],
+                topImagesWide: [],
+                works: [],
+                illustrations: [],
+            };
+
+            await store.writeCollections(input);
+            const result = await store.readCollections();
+
+            expect(result.topImages).toEqual(['third', 'first', 'second']);
+        });
+
+        it('replaces all collections on write', async () => {
+            const first: Collections = {
+                topImages: ['a', 'b'],
+                topImagesWide: ['c'],
+                works: [],
+                illustrations: ['d'],
+            };
+            await store.writeCollections(first);
+
+            const second: Collections = {
+                topImages: ['x'],
+                topImagesWide: [],
+                works: [],
+                illustrations: [],
+            };
+            await store.writeCollections(second);
+
+            const result = await store.readCollections();
+            expect(result.topImages).toEqual(['x']);
+            expect(result.topImagesWide).toEqual([]);
+            expect(result.illustrations).toEqual([]);
+        });
+
+        it('handles work with bilingual title and subtitle', async () => {
+            const input: Collections = {
+                topImages: [],
+                topImagesWide: [],
+                works: [
+                    {
+                        id: 'bilingual-work',
+                        title: { en: 'English Title', ja: '日本語タイトル' },
+                        subtitle: { en: 'English Sub', ja: '日本語サブ' },
+                        images: [],
+                    },
+                ],
+                illustrations: [],
+            };
+
+            await store.writeCollections(input);
+            const result = await store.readCollections();
+
+            expect(result.works[0]!.title).toEqual({ en: 'English Title', ja: '日本語タイトル' });
+            expect(result.works[0]!.subtitle).toEqual({ en: 'English Sub', ja: '日本語サブ' });
+        });
+
+        it('handles work without cover image', async () => {
+            const input: Collections = {
+                topImages: [],
+                topImagesWide: [],
+                works: [
+                    {
+                        id: 'no-cover',
+                        title: 'No Cover Work',
+                        images: ['img-1'],
+                    },
+                ],
+                illustrations: [],
+            };
+
+            await store.writeCollections(input);
+            const result = await store.readCollections();
+
+            expect(result.works[0]!.image).toBeUndefined();
+        });
+
+        it('handles multiple works with correct ordering', async () => {
+            const input: Collections = {
+                topImages: [],
+                topImagesWide: [],
+                works: [
+                    { id: 'first', title: 'First', images: [] },
+                    { id: 'second', title: 'Second', images: ['a'] },
+                    { id: 'third', title: 'Third', images: ['b', 'c'] },
+                ],
+                illustrations: [],
+            };
+
+            await store.writeCollections(input);
+            const result = await store.readCollections();
+
+            expect(result.works).toHaveLength(3);
+            expect(result.works[0]!.id).toBe('first');
+            expect(result.works[1]!.id).toBe('second');
+            expect(result.works[2]!.id).toBe('third');
+            expect(result.works[1]!.images).toEqual(['a']);
+            expect(result.works[2]!.images).toEqual(['b', 'c']);
+        });
+    });
+
+    describe('full round-trip', () => {
+        it('images survive full write-read cycle', async () => {
+            const input: ImageSet = {
+                'img/1': {
+                    id: 'img/1',
+                    format: 'jpeg',
+                    width: 1920,
+                    height: 1080,
+                    title: 'Landscape',
+                },
+                'img/2': {
+                    id: 'img/2',
+                    format: 'png',
+                    width: 500,
+                    height: 500,
+                    title: { en: 'Square', ja: '正方形' },
+                    description: 'A square image',
+                },
+            };
+
+            await store.writeImages(input);
+            const result = await store.readImages();
+
+            expect(result['img/1']).toEqual(input['img/1']);
+            expect(result['img/2']?.id).toBe('img/2');
+            expect(result['img/2']?.title).toEqual({ en: 'Square', ja: '正方形' });
+            expect(result['img/2']?.description).toBe('A square image');
+        });
+
+        it('collections survive full write-read cycle', async () => {
+            const input: Collections = {
+                topImages: ['top-1', 'top-2'],
+                topImagesWide: ['wide-1'],
+                works: [
+                    {
+                        id: 'my-work',
+                        image: 'cover',
+                        title: { en: 'My Work', ja: '私の作品' },
+                        subtitle: { en: 'A description', ja: '説明' },
+                        images: ['page-1', 'page-2', 'page-3'],
+                    },
+                ],
+                illustrations: ['ill-1'],
+            };
+
+            await store.writeCollections(input);
+            const result = await store.readCollections();
+
+            expect(result.topImages).toEqual(input.topImages);
+            expect(result.topImagesWide).toEqual(input.topImagesWide);
+            expect(result.illustrations).toEqual(input.illustrations);
+            expect(result.works).toHaveLength(1);
+            expect(result.works[0]!.id).toBe('my-work');
+            expect(result.works[0]!.image).toBe('cover');
+            expect(result.works[0]!.title).toEqual({ en: 'My Work', ja: '私の作品' });
+            expect(result.works[0]!.subtitle).toEqual({ en: 'A description', ja: '説明' });
+            expect(result.works[0]!.images).toEqual(['page-1', 'page-2', 'page-3']);
+        });
+    });
+});
+
+describe('getDataStore', () => {
+    it('returns JsonDataStore when platform has no DB', () => {
+        const store = getDataStore({});
+        expect(store).toBeInstanceOf(JsonDataStore);
+    });
+
+    it('returns JsonDataStore when platform is undefined', () => {
+        const store = getDataStore(undefined);
+        expect(store).toBeInstanceOf(JsonDataStore);
+    });
+
+    it('returns D1DataStore when platform.env.DB exists', () => {
+        const mockDb = createMockD1();
+        const store = getDataStore({ env: { DB: mockDb } });
+        expect(store).toBeInstanceOf(D1DataStore);
+    });
+});

--- a/src/lib/server/d1-types.ts
+++ b/src/lib/server/d1-types.ts
@@ -1,0 +1,31 @@
+/**
+ * Minimal D1 type definitions for use in this project.
+ * Avoids importing @cloudflare/workers-types globally, which overrides
+ * the built-in Response.json() return type from `any` to `unknown`.
+ */
+
+export interface D1ExecResult {
+    count: number;
+    duration: number;
+}
+
+export interface D1Result<T = unknown> {
+    results: T[];
+    success: boolean;
+    meta: D1ExecResult;
+}
+
+export interface D1PreparedStatement {
+    bind(...values: unknown[]): D1PreparedStatement;
+    first<T = unknown>(colName?: string): Promise<T | null>;
+    run(): Promise<D1ExecResult>;
+    all<T = unknown>(): Promise<D1Result<T>>;
+    raw<T = unknown>(): Promise<T[]>;
+}
+
+export interface D1Database {
+    prepare(query: string): D1PreparedStatement;
+    batch<T = unknown>(statements: D1PreparedStatement[]): Promise<D1Result<T>[]>;
+    exec(query: string): Promise<D1ExecResult>;
+    dump(): Promise<ArrayBuffer>;
+}

--- a/src/lib/server/data-store.test.ts
+++ b/src/lib/server/data-store.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import fs from 'fs';
-import { readImages, writeImages, readCollections, writeCollections } from './data-store';
+import { JsonDataStore, toTranslatable, fromTranslatable } from './data-store';
 import type { Collections } from './data-store';
 import type { ImageSet } from '../data';
 
@@ -37,65 +37,121 @@ const mockCollections: Collections = {
     illustrations: ['illustration/1', 'illustration/2'],
 };
 
-describe('readImages', () => {
-    beforeEach(() => {
-        vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(mockImages));
-    });
+describe('JsonDataStore', () => {
+    const store = new JsonDataStore();
 
     afterEach(() => {
         vi.restoreAllMocks();
     });
 
-    it('should read and parse images.json', () => {
-        const result = readImages();
+    it('readImages should read and parse images.json', async () => {
+        vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(mockImages));
+        const result = await store.readImages();
         expect(result['test/image-1']?.id).toBe('test/image-1');
         expect(result['test/image-2']?.format).toBe('png');
     });
-});
 
-describe('writeImages', () => {
-    afterEach(() => {
-        vi.restoreAllMocks();
-    });
-
-    it('should write images as formatted JSON', () => {
-        writeImages(mockImages);
+    it('writeImages should write images as formatted JSON', async () => {
+        await store.writeImages(mockImages);
         expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
         const [, content] = vi.mocked(fs.writeFileSync).mock.calls[0]!;
         const parsed = JSON.parse(content as string);
         expect(parsed['test/image-1'].id).toBe('test/image-1');
     });
-});
 
-describe('readCollections', () => {
-    beforeEach(() => {
+    it('readCollections should read and parse collections.json', async () => {
         vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(mockCollections));
-    });
-
-    afterEach(() => {
-        vi.restoreAllMocks();
-    });
-
-    it('should read and parse collections.json', () => {
-        const result = readCollections();
+        const result = await store.readCollections();
         expect(result.topImages).toEqual(['top/1', 'top/2']);
         expect(result.works).toHaveLength(1);
         expect(result.illustrations).toHaveLength(2);
     });
-});
 
-describe('writeCollections', () => {
-    afterEach(() => {
-        vi.restoreAllMocks();
-    });
-
-    it('should write collections as formatted JSON', () => {
-        writeCollections(mockCollections);
+    it('writeCollections should write collections as formatted JSON', async () => {
+        await store.writeCollections(mockCollections);
         expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
         const [, content] = vi.mocked(fs.writeFileSync).mock.calls[0]!;
         const parsed = JSON.parse(content as string);
         expect(parsed.topImages).toEqual(['top/1', 'top/2']);
         expect(parsed.works[0].id).toBe('work-1');
+    });
+});
+
+describe('toTranslatable', () => {
+    it('returns plain string when only text is provided', () => {
+        expect(toTranslatable('Hello', null)).toBe('Hello');
+    });
+
+    it('returns bilingual object when text_ja is provided', () => {
+        expect(toTranslatable('Hello', 'こんにちは')).toEqual({
+            en: 'Hello',
+            ja: 'こんにちは',
+        });
+    });
+
+    it('returns empty string when both are null', () => {
+        expect(toTranslatable(null, null)).toBe('');
+    });
+
+    it('handles null text with non-null text_ja', () => {
+        const result = toTranslatable(null, '日本語');
+        expect(result).toEqual({ ja: '日本語' });
+        expect(result).not.toHaveProperty('en');
+    });
+
+    it('handles empty strings', () => {
+        expect(toTranslatable('', null)).toBe('');
+    });
+});
+
+describe('fromTranslatable', () => {
+    it('converts plain string to text fields', () => {
+        expect(fromTranslatable('Hello')).toEqual({ text: 'Hello', text_ja: null });
+    });
+
+    it('converts bilingual object to text fields', () => {
+        expect(fromTranslatable({ en: 'Hello', ja: 'こんにちは' })).toEqual({
+            text: 'Hello',
+            text_ja: 'こんにちは',
+        });
+    });
+
+    it('handles partial bilingual object (en only)', () => {
+        expect(fromTranslatable({ en: 'English only' })).toEqual({
+            text: 'English only',
+            text_ja: null,
+        });
+    });
+
+    it('handles partial bilingual object (ja only)', () => {
+        expect(fromTranslatable({ ja: '日本語のみ' })).toEqual({
+            text: null,
+            text_ja: '日本語のみ',
+        });
+    });
+
+    it('handles empty string', () => {
+        expect(fromTranslatable('')).toEqual({ text: '', text_ja: null });
+    });
+
+    it('handles empty object', () => {
+        expect(fromTranslatable({})).toEqual({ text: null, text_ja: null });
+    });
+});
+
+describe('TranslatableString round-trip', () => {
+    it('plain string survives round-trip', () => {
+        const original = 'Hello World';
+        const { text, text_ja } = fromTranslatable(original);
+        const result = toTranslatable(text, text_ja);
+        expect(result).toBe(original);
+    });
+
+    it('bilingual object survives round-trip', () => {
+        const original = { en: 'Hello', ja: 'こんにちは' };
+        const { text, text_ja } = fromTranslatable(original);
+        const result = toTranslatable(text, text_ja);
+        expect(result).toEqual(original);
     });
 });
 

--- a/src/lib/server/data-store.ts
+++ b/src/lib/server/data-store.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import type { ImageSet, Work } from '../data';
+import type { Image, ImageSet, TranslatableString, Work } from '../data';
+import type { D1Database, D1PreparedStatement } from './d1-types';
 
 export interface Collections {
     topImages: string[];
@@ -8,6 +9,36 @@ export interface Collections {
     works: Work[];
     illustrations: string[];
 }
+
+export interface DataStore {
+    readImages(): Promise<ImageSet>;
+    writeImages(images: ImageSet): Promise<void>;
+    readCollections(): Promise<Collections>;
+    writeCollections(collections: Collections): Promise<void>;
+}
+
+// --- TranslatableString conversion helpers ---
+
+export function toTranslatable(text: string | null, text_ja: string | null): TranslatableString {
+    if (text_ja != null) {
+        const obj: { en?: string; ja?: string } = { ja: text_ja };
+        if (text != null) obj.en = text;
+        return obj;
+    }
+    return text ?? '';
+}
+
+export function fromTranslatable(ts: TranslatableString): {
+    text: string | null;
+    text_ja: string | null;
+} {
+    if (typeof ts === 'string') {
+        return { text: ts, text_ja: null };
+    }
+    return { text: ts.en ?? null, text_ja: ts.ja ?? null };
+}
+
+// --- JsonDataStore ---
 
 function projectRoot(): string {
     return process.cwd();
@@ -21,20 +52,243 @@ function collectionsPath(): string {
     return path.join(projectRoot(), 'src', 'collections.json');
 }
 
-export function readImages(): ImageSet {
-    const raw = fs.readFileSync(imagesPath(), 'utf-8');
-    return JSON.parse(raw) as ImageSet;
+export class JsonDataStore implements DataStore {
+    async readImages(): Promise<ImageSet> {
+        const raw = fs.readFileSync(imagesPath(), 'utf-8');
+        return JSON.parse(raw) as ImageSet;
+    }
+
+    async writeImages(images: ImageSet): Promise<void> {
+        fs.writeFileSync(imagesPath(), JSON.stringify(images, null, '  ') + '\n');
+    }
+
+    async readCollections(): Promise<Collections> {
+        const raw = fs.readFileSync(collectionsPath(), 'utf-8');
+        return JSON.parse(raw) as Collections;
+    }
+
+    async writeCollections(collections: Collections): Promise<void> {
+        fs.writeFileSync(collectionsPath(), JSON.stringify(collections, null, '    ') + '\n');
+    }
 }
 
-export function writeImages(images: ImageSet): void {
-    fs.writeFileSync(imagesPath(), JSON.stringify(images, null, '  ') + '\n');
+// --- D1DataStore ---
+
+interface ImageRow {
+    id: string;
+    format: string;
+    width: number;
+    height: number;
+    title: string | null;
+    title_ja: string | null;
+    description: string | null;
+    description_ja: string | null;
+    sha1: string | null;
+    created_at: string | null;
 }
 
-export function readCollections(): Collections {
-    const raw = fs.readFileSync(collectionsPath(), 'utf-8');
-    return JSON.parse(raw) as Collections;
+interface CollectionRow {
+    name: string;
+    image_id: string;
+    position: number;
 }
 
-export function writeCollections(collections: Collections): void {
-    fs.writeFileSync(collectionsPath(), JSON.stringify(collections, null, '    ') + '\n');
+interface WorkRow {
+    id: string;
+    cover_image_id: string | null;
+    title: string;
+    title_ja: string | null;
+    subtitle: string | null;
+    subtitle_ja: string | null;
+    position: number;
+}
+
+interface WorkImageRow {
+    work_id: string;
+    image_id: string;
+    position: number;
+}
+
+function rowToImage(row: ImageRow): Image {
+    const image: Image = {
+        id: row.id,
+        format: row.format as 'jpeg' | 'png',
+        width: row.width,
+        height: row.height,
+        title: toTranslatable(row.title, row.title_ja),
+    };
+    const desc = toTranslatable(row.description, row.description_ja);
+    if (desc !== '') {
+        image.description = desc;
+    }
+    return image;
+}
+
+export class D1DataStore implements DataStore {
+    constructor(private db: D1Database) {}
+
+    async readImages(): Promise<ImageSet> {
+        const { results } = await this.db.prepare('SELECT * FROM images').all<ImageRow>();
+
+        const images: ImageSet = {};
+        for (const row of results) {
+            images[row.id] = rowToImage(row);
+        }
+        return images;
+    }
+
+    async writeImages(images: ImageSet): Promise<void> {
+        const stmts: D1PreparedStatement[] = [this.db.prepare('DELETE FROM images')];
+
+        for (const image of Object.values(images)) {
+            const { text: title, text_ja: titleJa } = fromTranslatable(image.title);
+            const { text: desc, text_ja: descJa } = image.description
+                ? fromTranslatable(image.description)
+                : { text: null, text_ja: null };
+
+            stmts.push(
+                this.db
+                    .prepare(
+                        `INSERT INTO images (id, format, width, height, title, title_ja, description, description_ja)
+                         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+                    )
+                    .bind(
+                        image.id,
+                        image.format,
+                        image.width,
+                        image.height,
+                        title,
+                        titleJa,
+                        desc,
+                        descJa,
+                    ),
+            );
+        }
+
+        await this.db.batch(stmts);
+    }
+
+    async readCollections(): Promise<Collections> {
+        const [collectionResult, worksResult, workImagesResult] = await this.db.batch<
+            CollectionRow | WorkRow | WorkImageRow
+        >([
+            this.db.prepare('SELECT * FROM collections ORDER BY position'),
+            this.db.prepare('SELECT * FROM works ORDER BY position'),
+            this.db.prepare('SELECT * FROM work_images ORDER BY position'),
+        ]);
+
+        const collectionRows = (collectionResult?.results ?? []) as CollectionRow[];
+        const workRows = (worksResult?.results ?? []) as WorkRow[];
+        const workImageRows = (workImagesResult?.results ?? []) as WorkImageRow[];
+
+        const topImages: string[] = [];
+        const topImagesWide: string[] = [];
+        const illustrations: string[] = [];
+
+        for (const row of collectionRows) {
+            switch (row.name) {
+                case 'topImages':
+                    topImages.push(row.image_id);
+                    break;
+                case 'topImagesWide':
+                    topImagesWide.push(row.image_id);
+                    break;
+                case 'illustrations':
+                    illustrations.push(row.image_id);
+                    break;
+            }
+        }
+
+        const workImagesMap = new Map<string, string[]>();
+        for (const row of workImageRows) {
+            const arr = workImagesMap.get(row.work_id);
+            if (arr) {
+                arr.push(row.image_id);
+            } else {
+                workImagesMap.set(row.work_id, [row.image_id]);
+            }
+        }
+
+        const works: Work[] = workRows.map((row) => {
+            const work: Work = {
+                id: row.id,
+                title: toTranslatable(row.title, row.title_ja),
+                images: workImagesMap.get(row.id) ?? [],
+            };
+            if (row.cover_image_id != null) {
+                work.image = row.cover_image_id;
+            }
+            const subtitle = toTranslatable(row.subtitle, row.subtitle_ja);
+            if (subtitle !== '') {
+                work.subtitle = subtitle;
+            }
+            return work;
+        });
+
+        return { topImages, topImagesWide, works, illustrations };
+    }
+
+    async writeCollections(collections: Collections): Promise<void> {
+        const stmts: D1PreparedStatement[] = [
+            this.db.prepare('DELETE FROM collections'),
+            this.db.prepare('DELETE FROM work_images'),
+            this.db.prepare('DELETE FROM works'),
+        ];
+
+        const collectionInsert = this.db.prepare(
+            'INSERT INTO collections (name, image_id, position) VALUES (?, ?, ?)',
+        );
+
+        const addCollectionRows = (name: string, ids: string[]) => {
+            for (let i = 0; i < ids.length; i++) {
+                stmts.push(collectionInsert.bind(name, ids[i], i));
+            }
+        };
+
+        addCollectionRows('topImages', collections.topImages);
+        addCollectionRows('topImagesWide', collections.topImagesWide);
+        addCollectionRows('illustrations', collections.illustrations);
+
+        const workInsert = this.db.prepare(
+            `INSERT INTO works (id, cover_image_id, title, title_ja, subtitle, subtitle_ja, position)
+             VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        );
+        const workImageInsert = this.db.prepare(
+            'INSERT INTO work_images (work_id, image_id, position) VALUES (?, ?, ?)',
+        );
+
+        for (let wi = 0; wi < collections.works.length; wi++) {
+            const work = collections.works[wi]!;
+            const { text: title, text_ja: titleJa } = fromTranslatable(work.title);
+            const { text: subtitle, text_ja: subtitleJa } = work.subtitle
+                ? fromTranslatable(work.subtitle)
+                : { text: null, text_ja: null };
+
+            stmts.push(
+                workInsert.bind(
+                    work.id,
+                    work.image ?? null,
+                    title,
+                    titleJa,
+                    subtitle,
+                    subtitleJa,
+                    wi,
+                ),
+            );
+
+            for (let ii = 0; ii < work.images.length; ii++) {
+                stmts.push(workImageInsert.bind(work.id, work.images[ii], ii));
+            }
+        }
+
+        await this.db.batch(stmts);
+    }
+}
+
+// --- Factory ---
+
+export function getDataStore(platform?: App.Platform): DataStore {
+    const db = platform?.env?.DB;
+    if (db) return new D1DataStore(db);
+    return new JsonDataStore();
 }

--- a/src/lib/server/data-store.ts
+++ b/src/lib/server/data-store.ts
@@ -124,6 +124,14 @@ function rowToImage(row: ImageRow): Image {
     return image;
 }
 
+const D1_BATCH_LIMIT = 99;
+
+async function batchAll(db: D1Database, stmts: D1PreparedStatement[]): Promise<void> {
+    for (let i = 0; i < stmts.length; i += D1_BATCH_LIMIT) {
+        await db.batch(stmts.slice(i, i + D1_BATCH_LIMIT));
+    }
+}
+
 export class D1DataStore implements DataStore {
     constructor(private db: D1Database) {}
 
@@ -165,7 +173,7 @@ export class D1DataStore implements DataStore {
             );
         }
 
-        await this.db.batch(stmts);
+        await batchAll(this.db, stmts);
     }
 
     async readCollections(): Promise<Collections> {
@@ -281,7 +289,7 @@ export class D1DataStore implements DataStore {
             }
         }
 
-        await this.db.batch(stmts);
+        await batchAll(this.db, stmts);
     }
 }
 

--- a/src/routes/api/admin/collections/+server.ts
+++ b/src/routes/api/admin/collections/+server.ts
@@ -1,18 +1,20 @@
 import { json, error } from '@sveltejs/kit';
 import type { RequestHandler } from '@sveltejs/kit';
 import { requireDev, parseJsonBody } from '$lib/server/admin-guard';
-import { readCollections, writeCollections } from '$lib/server/data-store';
+import { getDataStore } from '$lib/server/data-store';
 
-export const GET: RequestHandler = async () => {
+export const GET: RequestHandler = async ({ platform }) => {
     requireDev();
-    const collections = readCollections();
+    const store = getDataStore(platform);
+    const collections = await store.readCollections();
     return json({ collections });
 };
 
-export const PATCH: RequestHandler = async ({ request }) => {
+export const PATCH: RequestHandler = async ({ request, platform }) => {
     requireDev();
     const body = await parseJsonBody(request);
-    const collections = readCollections();
+    const store = getDataStore(platform);
+    const collections = await store.readCollections();
 
     if (body.topImages !== undefined) {
         if (!Array.isArray(body.topImages)) throw error(400, 'topImages must be an array');
@@ -27,6 +29,6 @@ export const PATCH: RequestHandler = async ({ request }) => {
         collections.illustrations = body.illustrations as string[];
     }
 
-    writeCollections(collections);
+    await store.writeCollections(collections);
     return json({ collections });
 };

--- a/src/routes/api/admin/images/+server.ts
+++ b/src/routes/api/admin/images/+server.ts
@@ -1,17 +1,18 @@
 import { json, error } from '@sveltejs/kit';
 import type { RequestHandler } from '@sveltejs/kit';
 import { requireDev, getCloudflareConfig } from '$lib/server/admin-guard';
-import { readImages, writeImages } from '$lib/server/data-store';
+import { getDataStore } from '$lib/server/data-store';
 import { uploadImage, getImageInfo } from '$lib/server/cloudflare-images';
 import type { Image } from '$lib/data';
 
-export const GET: RequestHandler = async () => {
+export const GET: RequestHandler = async ({ platform }) => {
     requireDev();
-    const images = readImages();
+    const store = getDataStore(platform);
+    const images = await store.readImages();
     return json({ images: Object.values(images) });
 };
 
-export const POST: RequestHandler = async ({ request }) => {
+export const POST: RequestHandler = async ({ request, platform }) => {
     requireDev();
 
     const formData = await request.formData();
@@ -47,9 +48,10 @@ export const POST: RequestHandler = async ({ request }) => {
         title: title ? String(title) : id,
     };
 
-    const images = readImages();
+    const store = getDataStore(platform);
+    const images = await store.readImages();
     images[id] = newImage;
-    writeImages(images);
+    await store.writeImages(images);
 
     return json({ image: newImage }, { status: 201 });
 };

--- a/src/routes/api/admin/images/[...id]/+server.ts
+++ b/src/routes/api/admin/images/[...id]/+server.ts
@@ -2,27 +2,29 @@ import { json, error } from '@sveltejs/kit';
 import type { RequestHandler } from '@sveltejs/kit';
 import type { TranslatableString } from '$lib/data';
 import { requireDev, getCloudflareConfig, parseJsonBody } from '$lib/server/admin-guard';
-import { readImages, writeImages, readCollections, writeCollections } from '$lib/server/data-store';
+import { getDataStore } from '$lib/server/data-store';
 import { deleteImage as deleteCloudflareImage } from '$lib/server/cloudflare-images';
 
-export const GET: RequestHandler = async ({ params }) => {
+export const GET: RequestHandler = async ({ params, platform }) => {
     requireDev();
     const id = params.id;
     if (!id) throw error(400, 'Image ID is required');
 
-    const images = readImages();
+    const store = getDataStore(platform);
+    const images = await store.readImages();
     const image = images[id];
     if (!image) throw error(404, 'Image not found');
 
     return json({ image });
 };
 
-export const PATCH: RequestHandler = async ({ params, request }) => {
+export const PATCH: RequestHandler = async ({ params, request, platform }) => {
     requireDev();
     const id = params.id;
     if (!id) throw error(400, 'Image ID is required');
 
-    const images = readImages();
+    const store = getDataStore(platform);
+    const images = await store.readImages();
     const image = images[id];
     if (!image) throw error(404, 'Image not found');
 
@@ -38,17 +40,18 @@ export const PATCH: RequestHandler = async ({ params, request }) => {
     }
 
     images[id] = image;
-    writeImages(images);
+    await store.writeImages(images);
 
     return json({ image });
 };
 
-export const DELETE: RequestHandler = async ({ params }) => {
+export const DELETE: RequestHandler = async ({ params, platform }) => {
     requireDev();
     const id = params.id;
     if (!id) throw error(400, 'Image ID is required');
 
-    const images = readImages();
+    const store = getDataStore(platform);
+    const images = await store.readImages();
     if (!images[id]) throw error(404, 'Image not found');
 
     const config = getCloudflareConfig();
@@ -58,9 +61,9 @@ export const DELETE: RequestHandler = async ({ params }) => {
     }
 
     delete images[id];
-    writeImages(images);
+    await store.writeImages(images);
 
-    const collections = readCollections();
+    const collections = await store.readCollections();
     collections.topImages = collections.topImages.filter((imgId) => imgId !== id);
     collections.topImagesWide = collections.topImagesWide.filter((imgId) => imgId !== id);
     collections.illustrations = collections.illustrations.filter((imgId) => imgId !== id);
@@ -70,7 +73,7 @@ export const DELETE: RequestHandler = async ({ params }) => {
             delete work.image;
         }
     }
-    writeCollections(collections);
+    await store.writeCollections(collections);
 
     return json({ success: true });
 };

--- a/src/routes/api/admin/works/+server.ts
+++ b/src/routes/api/admin/works/+server.ts
@@ -2,15 +2,16 @@ import { json, error } from '@sveltejs/kit';
 import type { RequestHandler } from '@sveltejs/kit';
 import type { Work, TranslatableString } from '$lib/data';
 import { requireDev, parseJsonBody } from '$lib/server/admin-guard';
-import { readCollections, writeCollections } from '$lib/server/data-store';
+import { getDataStore } from '$lib/server/data-store';
 
-export const GET: RequestHandler = async () => {
+export const GET: RequestHandler = async ({ platform }) => {
     requireDev();
-    const collections = readCollections();
+    const store = getDataStore(platform);
+    const collections = await store.readCollections();
     return json({ works: collections.works });
 };
 
-export const POST: RequestHandler = async ({ request }) => {
+export const POST: RequestHandler = async ({ request, platform }) => {
     requireDev();
     const body = await parseJsonBody(request);
 
@@ -21,7 +22,8 @@ export const POST: RequestHandler = async ({ request }) => {
         throw error(400, 'Work title is required');
     }
 
-    const collections = readCollections();
+    const store = getDataStore(platform);
+    const collections = await store.readCollections();
 
     if (collections.works.some((w) => w.id === body.id)) {
         throw error(400, 'Work with this id already exists');
@@ -50,7 +52,7 @@ export const POST: RequestHandler = async ({ request }) => {
     }
 
     collections.works.push(newWork);
-    writeCollections(collections);
+    await store.writeCollections(collections);
 
     return json({ work: newWork }, { status: 201 });
 };

--- a/src/routes/api/admin/works/[id]/+server.ts
+++ b/src/routes/api/admin/works/[id]/+server.ts
@@ -2,14 +2,15 @@ import { json, error } from '@sveltejs/kit';
 import type { RequestHandler } from '@sveltejs/kit';
 import type { TranslatableString } from '$lib/data';
 import { requireDev, parseJsonBody } from '$lib/server/admin-guard';
-import { readCollections, writeCollections } from '$lib/server/data-store';
+import { getDataStore } from '$lib/server/data-store';
 
-export const PATCH: RequestHandler = async ({ params, request }) => {
+export const PATCH: RequestHandler = async ({ params, request, platform }) => {
     requireDev();
     const id = params.id;
     if (!id) throw error(400, 'Work ID is required');
 
-    const collections = readCollections();
+    const store = getDataStore(platform);
+    const collections = await store.readCollections();
     const work = collections.works.find((w) => w.id === id);
     if (!work) throw error(404, 'Work not found');
 
@@ -37,21 +38,22 @@ export const PATCH: RequestHandler = async ({ params, request }) => {
         work.images = body.images;
     }
 
-    writeCollections(collections);
+    await store.writeCollections(collections);
     return json({ work });
 };
 
-export const DELETE: RequestHandler = async ({ params }) => {
+export const DELETE: RequestHandler = async ({ params, platform }) => {
     requireDev();
     const id = params.id;
     if (!id) throw error(400, 'Work ID is required');
 
-    const collections = readCollections();
+    const store = getDataStore(platform);
+    const collections = await store.readCollections();
     const index = collections.works.findIndex((w) => w.id === id);
     if (index === -1) throw error(404, 'Work not found');
 
     collections.works.splice(index, 1);
-    writeCollections(collections);
+    await store.writeCollections(collections);
 
     return json({ success: true });
 };

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,7 +3,6 @@ pages_build_output_dir = ".svelte-kit/cloudflare"
 compatibility_date = "2024-09-23"
 compatibility_flags = ["nodejs_compat"]
 
-[[d1_databases]]
-binding = "DB"
-database_name = "sasage-web-db"
-database_id = "placeholder-will-be-set-in-dashboard"
+# D1 database binding is configured in the Cloudflare Pages dashboard.
+# For local development with D1, use:
+#   wrangler pages dev --d1=DB=<database-id>

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,3 +2,8 @@ name = "sasage-web"
 pages_build_output_dir = ".svelte-kit/cloudflare"
 compatibility_date = "2024-09-23"
 compatibility_flags = ["nodejs_compat"]
+
+[[d1_databases]]
+binding = "DB"
+database_name = "sasage-web-db"
+database_id = "placeholder-will-be-set-in-dashboard"


### PR DESCRIPTION
## Description

This PR adds Cloudflare D1 database support to the project while maintaining backward compatibility with JSON file-based storage. The data layer is refactored to use an abstract `DataStore` interface with two implementations: `D1DataStore` for database operations and `JsonDataStore` for file-based storage. A factory function automatically selects the appropriate implementation based on the platform environment.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Code refactoring
- [x] Test improvements

## Changes Made

- **Data Store Abstraction**: Created `DataStore` interface with `readImages()`, `writeImages()`, `readCollections()`, and `writeCollections()` methods
- **D1DataStore Implementation**: Full database implementation with SQL schema for images, collections, works, and work_images tables
- **JsonDataStore Implementation**: Refactored existing file-based storage into a class implementing the `DataStore` interface
- **TranslatableString Helpers**: Added `toTranslatable()` and `fromTranslatable()` utility functions to convert between database rows and domain objects
- **Factory Function**: `getDataStore(platform)` automatically selects D1 or JSON storage based on `platform.env.DB`
- **D1 Type Definitions**: Created minimal type definitions in `d1-types.ts` to avoid global type pollution from `@cloudflare/workers-types`
- **Database Schema**: Added `migrations/0001_initial_schema.sql` with tables for images, collections, works, and work_images
- **Migration Script**: Added `scripts/migrate-to-d1.ts` to generate SQL INSERT statements from existing JSON files
- **API Routes**: Updated all admin API routes to use `getDataStore(platform)` instead of direct function calls
- **Type Definitions**: Updated `app.d.ts` to include `Platform.env.DB` type
- **Wrangler Config**: Added D1 database binding configuration

## Testing

- [x] Comprehensive unit tests added for `D1DataStore` with in-memory mock implementation (`d1-data-store.test.ts`)
- [x] Tests cover image CRUD operations, collection management, bilingual content, and full round-trip scenarios
- [x] Existing `JsonDataStore` tests refactored and passing
- [x] Helper function tests for `toTranslatable()` and `fromTranslatable()`
- [x] Factory function tests verify correct store selection based on platform
- [x] Admin API tests updated to mock `getDataStore` factory

## Performance Impact

- [x] No performance impact expected
- Database queries are batched where possible to minimize round-trips
- JSON file operations remain unchanged for non-D1 environments

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code completed
- [x] TypeScript compilation successful
- [x] No console.log statements in production code
- [x] Backward compatibility maintained with JSON storage

## Additional Notes

The implementation uses a simple SQL parser in the mock D1 implementation for testing, supporting INSERT, SELECT, and DELETE operations with ORDER BY. The migration script can be used to seed the D1 database from existing JSON files:

```bash
npx tsx scripts/migrate-to-d1.ts > migrations/0002_seed_data.sql
wrangler d1 execute sasage-web-db --local --file=migrations/0002_seed_data.sql
```

The `D1Database` binding in `wrangler.toml` uses a placeholder ID that should be updated with the actual database ID from Cloudflare.

https://claude.ai/code/session_01ToUdUNbAPPMgM98ow8Just