### PR TITLE
Add hash-password script and document admin auth setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,44 @@ Put the following in .env file.
 CLOUDFLARE_ACCOUNT_ID = <account id>;
 CLOUDFLARE_IMAGES_API_TOKEN = <api token>;
 ```
+
+# Admin authentication
+
+The admin GUI at `/admin` and admin API at `/api/admin/*` are protected by
+password authentication. Sessions are stored in D1 (production) or in memory
+(dev), and the password is stored as a PBKDF2 hash in an environment variable.
+
+## Local development
+
+In dev mode, if `ADMIN_PASSWORD_HASH` is not set, a default password of
+`admin` is used automatically. To use a custom dev password, add the hash to
+your `.env` file:
+
+```
+ADMIN_PASSWORD_HASH=<salt_hex>:<hash_hex>
+```
+
+## Production setup
+
+1. Generate a password hash:
+
+    ```
+    pnpm hash-password
+    ```
+
+    (Or pass the password as an argument: `pnpm hash-password 'my-password'`.)
+
+2. In the Cloudflare Pages dashboard, open **Settings → Environment variables**
+   and add a new variable:
+    - Name: `ADMIN_PASSWORD_HASH`
+    - Value: the `salt_hex:hash_hex` string from step 1
+    - Type: **Secret** (encrypted)
+
+3. Apply the sessions table migration to D1:
+
+    ```
+    wrangler d1 execute <database-name> --file=migrations/0002_sessions.sql --remote
+    ```
+
+To change the password later, repeat step 1 with a new password and update the
+`ADMIN_PASSWORD_HASH` variable in Cloudflare Pages.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "license": "MIT",
     "scripts": {
         "upload-images": "node scripts/upload.mjs",
+        "hash-password": "node scripts/hash-password.mjs",
         "dev": "vite dev",
         "build": "vite build",
         "package": "svelte-kit package",

--- a/scripts/hash-password.mjs
+++ b/scripts/hash-password.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+/**
+ * Generate an ADMIN_PASSWORD_HASH for the admin authentication system.
+ *
+ * Usage:
+ *   pnpm hash-password
+ *   pnpm hash-password <password>
+ *
+ * The output is in `salt_hex:hash_hex` format (PBKDF2-SHA-256, 100k iterations),
+ * matching the algorithm in src/lib/server/auth.ts. Paste the output into your
+ * Cloudflare Pages environment variable `ADMIN_PASSWORD_HASH` (as a Secret).
+ */
+
+import { createInterface } from 'node:readline/promises';
+import { stdin, stdout } from 'node:process';
+
+const PBKDF2_ITERATIONS = 100_000;
+
+function hexEncode(buffer) {
+    return Array.from(new Uint8Array(buffer))
+        .map((b) => b.toString(16).padStart(2, '0'))
+        .join('');
+}
+
+async function hashPassword(password) {
+    const salt = crypto.getRandomValues(new Uint8Array(16));
+    const keyMaterial = await crypto.subtle.importKey(
+        'raw',
+        new TextEncoder().encode(password),
+        'PBKDF2',
+        false,
+        ['deriveBits'],
+    );
+    const bits = await crypto.subtle.deriveBits(
+        {
+            name: 'PBKDF2',
+            salt: new Uint8Array(salt),
+            iterations: PBKDF2_ITERATIONS,
+            hash: 'SHA-256',
+        },
+        keyMaterial,
+        256,
+    );
+    return `${hexEncode(salt)}:${hexEncode(bits)}`;
+}
+
+async function readPasswordInteractive() {
+    const rl = createInterface({ input: stdin, output: stdout });
+    try {
+        const pw1 = await rl.question('Password: ');
+        if (!pw1) {
+            console.error('Password cannot be empty');
+            process.exit(1);
+        }
+        const pw2 = await rl.question('Confirm:  ');
+        if (pw1 !== pw2) {
+            console.error('Passwords do not match');
+            process.exit(1);
+        }
+        return pw1;
+    } finally {
+        rl.close();
+    }
+}
+
+const argPassword = process.argv[2];
+const password = argPassword ?? (await readPasswordInteractive());
+
+const hash = await hashPassword(password);
+
+console.log('');
+console.log('ADMIN_PASSWORD_HASH value:');
+console.log(hash);
+console.log('');
+console.log('Set this as the `ADMIN_PASSWORD_HASH` environment variable in');
+console.log('Cloudflare Pages → Settings → Environment variables (as a Secret).');


### PR DESCRIPTION
## Summary

Follow-up to #123 — provides tooling and documentation for setting up the admin password in production.

- `scripts/hash-password.mjs` generates `ADMIN_PASSWORD_HASH` values using the same PBKDF2-SHA-256 algorithm (100k iterations) as `src/lib/server/auth.ts`
- Interactive mode prompts for the password with confirmation; argument mode accepts the password as argv[2]
- `pnpm hash-password` alias added
- README documents both local dev defaults and the production setup (hash generation, Cloudflare Pages env var, D1 migration)

## Test plan

- [x] Manual: `pnpm hash-password foo` produces a valid `salt_hex:hash_hex` output
- [x] Verified the generated hash verifies correctly against the `verifyPassword` algorithm from `src/lib/server/auth.ts`
- [x] `pnpm lint` — clean
- [x] Try `pnpm hash-password` interactively and confirm the password confirmation prompt works

https://claude.ai/code/session_01EwpsLYJhRdosCvLa9MsujP