### PR TITLE
Phase 8: Fix Svelte 5 rune warnings and document admin architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,27 +171,93 @@ pnpm upload-images
 - `/about` - About page
 - `/collections/[...id]` - Collection pages
 
+### Admin Routes (authenticated)
+
+- `/admin` - Dashboard
+- `/admin/login` - Password login
+- `/admin/images` - Image gallery, upload, metadata editing
+- `/admin/collections` - Collection reordering and membership management
+- `/admin/works` - Works CRUD (title, subtitle, cover, work images)
+
+All `/admin/*` and `/api/admin/*` routes are gated by `src/hooks.server.ts`, which validates the `admin_session` cookie against the session store. Unauthenticated requests are redirected to `/admin/login` (pages) or rejected with 401 (API).
+
+### Admin API
+
+- `POST   /api/admin/auth/login` - password → session cookie
+- `POST   /api/admin/auth/logout`
+- `GET    /api/admin/auth/status` - current session state
+- `GET    /api/admin/images`, `PATCH /api/admin/images/[id]`, `DELETE /api/admin/images/[id]`
+- `POST   /api/admin/images/upload` - proxies to Cloudflare Images
+- `GET    /api/admin/collections`, `PUT /api/admin/collections/[name]`
+- `GET    /api/admin/works`, `POST /api/admin/works`, `PATCH /api/admin/works/[id]`, `DELETE /api/admin/works/[id]`, `PUT /api/admin/works/reorder`
+
+### Data Layer: D1 + JSON Fallback
+
+The public site and admin API share a `DataStore` interface (`src/lib/server/data-store.ts`). In production, `D1DataStore` (`src/lib/server/d1-data-store.ts`) reads and writes Cloudflare D1. In local dev without a `DB` binding, the layout server falls back to the bundled `src/images.json` / `src/collections.json` for read-only rendering — admin writes require D1.
+
+D1 schema (see `migrations/`):
+
+- `images(id, format, width, height, title, title_ja, description, description_ja, sha1, created_at)`
+- `collections(name, image_id, position)` - ordered membership
+- `works(id, cover_image_id, title, title_ja, subtitle, subtitle_ja, position)`
+- `work_images(work_id, image_id, position)` - ordered membership
+- `sessions(token, expires_at)` with `idx_sessions_expires_at`
+
+### Authentication
+
+- Passwords are stored as `salt_hex:hash_hex` PBKDF2-SHA256 (100k iterations) in the `ADMIN_PASSWORD_HASH` secret.
+- Generate a hash with `pnpm hash-password <password>` and store it in the Cloudflare Pages environment (or `.env` for dev).
+- In dev, if `ADMIN_PASSWORD_HASH` is unset, the password defaults to `admin` (logged once to the console).
+- Session tokens are 32 random bytes (hex). Sessions live in the `sessions` D1 table in production and an in-memory `MemorySessionStore` in dev.
+- `SESSION_MAX_AGE = 7 days`. The `admin_session` cookie is HttpOnly, SameSite=Lax, Secure in prod.
+
 ### Image Pipeline
 
 1. Local images stored in `/images/` directory
 2. Upload script (`scripts/upload.mjs`) processes and uploads to Cloudflare Images
-3. Image metadata stored in `src/images.json`
-4. Dynamic image variants served via Cloudflare Images CDN
+3. Image metadata stored in `src/images.json` (legacy seed data for D1 + dev fallback)
+4. Admin upload endpoint streams new uploads to Cloudflare Images and records metadata in D1
+5. Dynamic image variants served via Cloudflare Images CDN
 
 ### Content Management
 
-- Content definitions in `src/lib/data.ts`
-- Bilingual support via `TranslatableString` type
-- Works and illustrations managed as TypeScript objects
+- Bilingual support via `TranslatableString` type (`{ en, ja }`)
+- Public data is loaded from D1 in `src/routes/+layout.server.ts` with static-JSON fallback
+- Admin writes go through `DataStore` methods, so the same validation applies to all mutation paths
+
+### Environment Setup
+
+Required bindings and secrets (set in Cloudflare Pages → Settings → Functions):
+
+- `DB` - D1 database binding (name: `sasage-web-db`, see `wrangler.toml`)
+- `ADMIN_PASSWORD_HASH` - PBKDF2 hash from `pnpm hash-password`
+- Cloudflare Images credentials for the upload script (see `scripts/upload.mjs`)
+
+Apply D1 migrations with:
+
+```bash
+pnpm wrangler d1 migrations apply sasage-web-db --remote
+```
 
 ## Key Files to Understand
 
-- `src/lib/data.ts` - Main data definitions and image utilities
+- `src/lib/data.ts` - Shared data definitions, types, and image utilities
 - `src/lib/img.svelte` - Responsive image component with Cloudflare integration
 - `src/lib/image-grid.svelte` - Grid layout for image galleries
+- `src/lib/image-cell.svelte` - Individual cell with aspect-ratio-aware layout
 - `src/lib/slideshow-source.ts` - Slideshow logic with image preloading
+- `src/lib/server/data-store.ts` - `DataStore` interface used by public + admin
+- `src/lib/server/d1-data-store.ts` - D1 implementation of `DataStore`
+- `src/lib/server/auth.ts` - PBKDF2 hashing, session stores (memory + D1)
+- `src/lib/server/cloudflare-images.ts` - Cloudflare Images API client
+- `src/hooks.server.ts` - Admin route auth guard
+- `src/routes/api/admin/` - Admin REST endpoints
+- `src/routes/admin/` - Admin UI (SvelteKit pages)
+- `src/lib/admin/` - Admin-only components (image-picker, works-crud, etc.)
+- `migrations/` - D1 schema migrations
 - `scripts/upload.mjs` - Image upload automation
-- `src/images.json` - Image metadata (generated by upload script)
+- `scripts/hash-password.mjs` - Admin password hash generator
+- `src/images.json` - Image metadata (seed data + dev fallback)
 - `eslint.config.js` - ESLint v9 flat configuration
 - `vitest.config.ts` - Test configuration and setup
 - `.github/workflows/` - CI/CD pipeline definitions

--- a/src/lib/image-cell.svelte
+++ b/src/lib/image-cell.svelte
@@ -20,31 +20,35 @@
         r4x3?: boolean;
     } = $props();
 
-    const image = id ? findImage((page.data.images ?? {}) as ImageSet, id) : null;
-    let cellClass = 'px-16 sm:px-8';
-    let span = 1;
+    const image = $derived(id ? findImage((page.data.images ?? {}) as ImageSet, id) : null);
 
-    if (image) {
-        const { width, height } = image;
+    const layout = $derived.by(() => {
+        let cellClass = 'px-16 sm:px-8';
+        let span = 1;
 
-        if (width && height) {
-            const ratio = square ? 1.01 : r4x3 ? 4 / 3 : width / height;
-            if (ratio >= 1.5) {
-                cellClass = 'px-2';
+        if (image) {
+            const { width, height } = image;
 
-                if (columns > 1) {
-                    cellClass += ' col-span-2';
-                    span = 2;
-                }
-            } else if (ratio > 1.0) cellClass = 'px-8 sm:px-2';
+            if (width && height) {
+                const ratio = square ? 1.01 : r4x3 ? 4 / 3 : width / height;
+                if (ratio >= 1.5) {
+                    cellClass = 'px-2';
+
+                    if (columns > 1) {
+                        cellClass += ' col-span-2';
+                        span = 2;
+                    }
+                } else if (ratio > 1.0) cellClass = 'px-8 sm:px-2';
+            }
         }
-    }
+        return { cellClass, span };
+    });
 </script>
 
 {#if image}
-    <div class="{cellClass} my-8 sm:my-6" data-sveltekit-preload-data="hover">
+    <div class="{layout.cellClass} my-8 sm:my-6" data-sveltekit-preload-data="hover">
         <a href={link}>
-            <Img className="shadow-xl" {columns} {span} {square} {r4x3} {image} />
+            <Img className="shadow-xl" {columns} span={layout.span} {square} {r4x3} {image} />
             {#if title}
                 <p class="mt-3 text-center text-xl lg:text-2xl font-extralight">{title}</p>
             {/if}

--- a/src/lib/slideshow.svelte
+++ b/src/lib/slideshow.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { onDestroy } from 'svelte';
+    import { onDestroy, untrack } from 'svelte';
     import type { ImageSet } from './data';
     import { page } from '$app/state';
     import Img from './img.svelte';
@@ -10,7 +10,11 @@
     const interval = 8000;
     const duration = 1000;
 
-    const imageSource = source((page.data.images ?? {}) as ImageSet, images, interval);
+    // The slideshow's source and transition are intentionally initialized once from
+    // the starting props; they manage their own interval and subscription lifecycle.
+    const imageSource = untrack(() =>
+        source((page.data.images ?? {}) as ImageSet, images, interval),
+    );
     const transition = createTransition(imageSource);
 
     let imageA = $state(transition.imageA);


### PR DESCRIPTION
## Summary

Final cleanup pass for the admin GUI project (Issue #113, Phase 8). Focused on concrete polish rather than speculative features, since the repository is already in excellent shape (242 tests passing, 0 type errors).

### Svelte 5 rune warnings — now zero

`pnpm check` previously surfaced 8 warnings in `image-cell.svelte` and `slideshow.svelte` left over from the Phase 0 runes migration:

- `image-cell.svelte`: `cellClass` / `span` were plain `let` (non-reactive) and props (`id`, `square`, `r4x3`, `columns`) were captured at init instead of inside reactive closures. Moved the computation into `$derived` / `$derived.by` so aspect-ratio classes re-evaluate when props change.
- `slideshow.svelte`: the one-shot `source()` call warned about reading `images` outside a reactive scope. Wrapped in `untrack(...)` with a comment, since the slideshow intentionally initialises the source + transition once and manages its own interval lifecycle.

### CLAUDE.md — admin architecture documented

CLAUDE.md was silent on everything Phases 5-7 added. Added sections covering:

- Admin routes (`/admin/*`) and the `hooks.server.ts` auth guard
- Admin REST API surface (`/api/admin/auth|images|collections|works`)
- D1 data layer: `DataStore` interface, `D1DataStore`, dev-mode JSON fallback, full table schema
- Authentication: PBKDF2 hashing, session stores, `admin_session` cookie, dev default password
- Environment setup: required bindings (`DB`, `ADMIN_PASSWORD_HASH`), `pnpm hash-password`, D1 migration command

Also expanded the "Key Files" list with the new server/admin modules and the `migrations/` directory.

### What this PR does not do

Issue #113 lists a large set of aspirational items (mobile hamburger, optimistic UI, virtual scroll, 120+ tests target). Test count is already 242 (well past the 120 target), and the rest are product decisions rather than cleanup — intentionally left for future scoped issues.

## Test plan

- [x] `pnpm check` — 0 errors, 0 warnings
- [x] `pnpm test:run` — 242/242 pass
- [x] `pnpm lint` — clean
- [x] `pnpm build` — succeeds (Cloudflare adapter)

Closes #113

https://claude.ai/code/session_016unwpJD1vbFEG7BscL7425